### PR TITLE
Fix indentation in usage output for mkaltfs and altfsindextool

### DIFF
--- a/messages/bin_altfsindextool/root.txt
+++ b/messages/bin_altfsindextool/root.txt
@@ -101,7 +101,7 @@ root:table {
 		AIX0059I:string { "      --kmi-backend=<name>   Use the specified key manager interface backend (default: %s)" }
 		AIX0060I:string { "  -q, --quiet                Suppress progress information and general messages" }
 		AIX0061I:string { "  -t, --trace                Enable function call tracing" }
-		AIX0062I:string { "  -V, --version             Version information" }
+		AIX0062I:string { "  -V, --version              Version information" }
 		AIX0063I:string { "  -h, --help                 This help" }
 		AIX0064I:string { "Usage example:" }
 		AIX0065I:string { "  %s --device=%s -p=%d" }

--- a/messages/bin_mkaltfs/root.txt
+++ b/messages/bin_mkaltfs/root.txt
@@ -116,7 +116,7 @@ root:table {
 		AMK0074I:string { "  -k, --keep-capacity       Keep the tape medium's total capacity proportion" }
 		AMK0075I:string { "  -f, --force               Force to format medium" }
 		AMK0076I:string { "      --kmi-backend=<name>  Use the specified key manager interface backend (default: %s)" }
-		AMK0077I:string { "      --syslogtrace               Enable diagnostic output to stderr and syslog" }
+		AMK0077I:string { "      --syslogtrace         Enable diagnostic output to stderr and syslog" }
 		AMK0078I:string { "  -V, --version             Version information" }
 		AMK0079I:string { "      --long-wipe           Unformat the medium and erase any data on the tape by overwriting special data pattern.\n                            This operation takes over 3 hours. Once you start, you cannot interrupt it" }
 		AMK0080I:string { "      --destructive         Use destructive format/unformat. This operation takes longer time\n                            in the LTO9 drive or later because of the media optimization procedure" }


### PR DESCRIPTION
## What

Fix indentation in usage output for mkaltfs and altfsindextool. Previously two messages were written with a wrong offset, resulting in a misaligned output.

## How

Adjusted spaces in text messages to fix indentation.

## Testing

### Test steps

Ensured that mkaltfs -h, altfsindextool -h print properly formatted output

### Test environment

- Tested on: Ubuntu 24.04, Arch Linux
- Added automated tests: None

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## AI Usage

- [x] No AI tools were used in this contribution
- [ ] AI tools were used (please describe below)