### PR TITLE
Improve ICU configuration block

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -324,16 +324,9 @@ fi
 dnl
 dnl Check for ICU
 dnl
-AC_MSG_CHECKING(ICU version)
-ICU_MODULE_VERSION="`pkg-config --modversion icu-i18n 2> /dev/null`";
-ICU_MODULE_CFLAGS="`pkg-config --cflags icu-i18n 2> /dev/null`";
-ICU_MODULE_LIBS="`pkg-config --libs icu-i18n 2> /dev/null`";
-AC_MSG_RESULT([$ICU_MODULE_VERSION])
-
-if test -z "$ICU_MODULE_VERSION"
-then
-    PKG_CHECK_MODULES([ICU_MODULE], [icu-uc >= 0.21])
-fi
+PKG_CHECK_EXISTS([icu-i18n],
+    [PKG_CHECK_MODULES([ICU_MODULE], [icu-i18n])],
+    [PKG_CHECK_MODULES([ICU_MODULE], [icu-uc >= 0.21])])
 
 AC_MSG_CHECKING([for using ICU6x (unorm2) functions forcibly])
 AC_ARG_ENABLE([icu_6x],
@@ -347,14 +340,11 @@ if test "x${icu_6x}" = "xyes"
 then
     AM_EXTRA_CPPFLAGS="${AM_EXTRA_CPPFLAGS} -D USE_UNORM2"
 else
-    AC_MSG_CHECKING(for using unorm2 functions)
-    if test "${ICU_MODULE_VERSION%%.*}" -ge "56"
-    then
-        AM_EXTRA_CPPFLAGS="${AM_EXTRA_CPPFLAGS} -D USE_UNORM2"
-        AC_MSG_RESULT(yes)
-    else
-        AC_MSG_RESULT(no)
-    fi
+    save_CFLAGS="$CFLAGS"
+    CFLAGS="$CFLAGS $ICU_MODULE_CFLAGS"
+    AC_CHECK_HEADER([unicode/unorm2.h],
+        [AM_EXTRA_CPPFLAGS="${AM_EXTRA_CPPFLAGS} -D USE_UNORM2"])
+    CFLAGS="$save_CFLAGS"
 fi
 
 dnl


### PR DESCRIPTION
## What

Replace pkg-config shell calls with native macros to allow CFLAGS and LDFLAGS overrides with environment variables.

Also replace version string comparison with unorm2.h header probe.

## How

Use native autoconf approach to detect and configure ICU with pkg-config - this is already done for other libraries (fuse, libxml2, uuid).

No documentation change is needed - `./configure --help` already mentions all env overrides.

## Why (optional)

The change targets Tier 3 platforms, in particular Linux distributions where icu-config is still preferred. For such systems, the following configure line now leads to a successful build:

```
./configure ICU_MODULE_CFLAGS="$(icu-config --cppflags)" ICU_MODULE_LIBS="$(icu-config --ldflags)"
```

## Testing

### Test steps

Library is detected with pkg-config - no differences from current main branch
```
./autogen.sh
./configure
grep ICU_MODULE_ Makefile
```

Library flags are set with environment variables
```
./autogen.sh
./configure ICU_MODULE_CFLAGS="$(icu-config --cppflags)" ICU_MODULE_LIBS="$(icu-config --ldflags)"
grep ICU_MODULE_ Makefile
```

### Test environment

- Tested on: Ubuntu 24.04, Arch Linux
- Added automated tests: none

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## AI Usage

- [ ] No AI tools were used in this contribution
- [x] AI tools were used (please describe below)

**AI tool(s) used:** Claude Code
**Scope of AI assistance:** code generation, review