### PR TITLE
chore(devcontainer): drop postCreateCommand to clarify build state

### DIFF
--- a/.devcontainer/rocky9/devcontainer.json
+++ b/.devcontainer/rocky9/devcontainer.json
@@ -14,7 +14,6 @@
     },
     "mounts": [
         "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind"
-    ],    
-    "postCreateCommand": "./autogen.sh && ./configure --prefix=/workspaces/altfs && bear -- make -j$(nproc)",
+    ],
     "remoteUser": "vscode"
 }

--- a/.devcontainer/ubuntu2404/devcontainer.json
+++ b/.devcontainer/ubuntu2404/devcontainer.json
@@ -19,6 +19,5 @@
         "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind"
     ],
     "runArgs": ["--privileged", "--device=/dev/fuse", "--cap-add=SYS_ADMIN"],
-    "postCreateCommand": "./autogen.sh && ./configure --prefix=/workspaces/altfs && bear -- make -j$(nproc)",
     "remoteUser": "vscode"
 }


### PR DESCRIPTION
## Summary

- Both devcontainer definitions (Ubuntu 24.04 / Rocky 9) ran `autogen.sh + configure + bear -- make` as their `postCreateCommand`.
- That command only ran at **container creation time**, never on restart, and stopped before `make install` — so `/workspaces/altfs/{bin,lib,...}` was never populated automatically anyway. The result was a build state that quietly drifted from the source tree and was hard to reason about.
- Drop the `postCreateCommand` from both definitions. Developers now run `autogen → configure → make → make install` explicitly, which makes the installed binaries unambiguously match a known build.

## Test plan

- [ ] Rebuild a devcontainer (Ubuntu and/or Rocky) and confirm it comes up cleanly without the post-create hook.
- [ ] In the rebuilt container, run `./autogen.sh && ./configure --prefix=/workspaces/altfs && make && make install` and confirm `/workspaces/altfs/bin/altfs` is populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)