### PR TITLE
test: scaffold pytest harness for FUSE filesystem API tests

### DIFF
--- a/.github/workflows/scenario.yml
+++ b/.github/workflows/scenario.yml
@@ -10,8 +10,8 @@ defaults:
     shell: bash
 
 jobs:
-  fsapi:
-    name: FS API (Ubuntu 24.04)
+  tests:
+    name: FS API + scenarios (Ubuntu 24.04)
     runs-on: ubuntu-24.04
     env:
       DEBIAN_FRONTEND: noninteractive
@@ -57,3 +57,8 @@ jobs:
         env:
           ALTFS_PREFIX: ${{ github.workspace }}/_install
         run: bash tests/fsapi/run.sh -v
+
+      - name: Run scenario tests
+        env:
+          ALTFS_PREFIX: ${{ github.workspace }}/_install
+        run: bash tests/scenarios/run.sh -v

--- a/.github/workflows/scenario.yml
+++ b/.github/workflows/scenario.yml
@@ -144,5 +144,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.info
           fail_ci_if_error: false

--- a/.github/workflows/scenario.yml
+++ b/.github/workflows/scenario.yml
@@ -1,0 +1,59 @@
+name: Scenario tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  fsapi:
+    name: FS API (Ubuntu 24.04)
+    runs-on: ubuntu-24.04
+    env:
+      DEBIAN_FRONTEND: noninteractive
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            autoconf \
+            automake \
+            libtool \
+            make \
+            gcc \
+            pkg-config \
+            libfuse-dev \
+            libxml2-dev \
+            libicu-dev \
+            uuid-dev \
+            icu-devtools \
+            fuse \
+            python3 \
+            python3-pytest \
+            git \
+            ca-certificates
+
+      - name: autogen
+        run: ./autogen.sh
+
+      - name: configure
+        run: ./configure --prefix="${GITHUB_WORKSPACE}/_install" --enable-warning-as-error
+
+      - name: make
+        run: make -j"$(nproc)"
+
+      - name: make install
+        run: make install
+
+      - name: Run FS API tests
+        env:
+          ALTFS_PREFIX: ${{ github.workspace }}/_install
+        run: bash tests/fsapi/run.sh -v

--- a/.github/workflows/scenario.yml
+++ b/.github/workflows/scenario.yml
@@ -62,3 +62,87 @@ jobs:
         env:
           ALTFS_PREFIX: ${{ github.workspace }}/_install
         run: bash tests/scenarios/run.sh -v
+
+  coverage:
+    name: Coverage (Ubuntu 24.04)
+    runs-on: ubuntu-24.04
+    env:
+      DEBIAN_FRONTEND: noninteractive
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            autoconf \
+            automake \
+            libtool \
+            make \
+            gcc \
+            pkg-config \
+            libfuse-dev \
+            libxml2-dev \
+            libicu-dev \
+            uuid-dev \
+            icu-devtools \
+            fuse \
+            python3 \
+            python3-pytest \
+            git \
+            ca-certificates \
+            lcov
+
+      - name: autogen
+        run: ./autogen.sh
+
+      # --coverage emits the gcov instrumentation; -O0 / -g keep the
+      # mapping back to source lines accurate. --enable-warning-as-error
+      # is intentionally dropped here — the instrumentation can introduce
+      # warnings that the production build (covered by the tests job
+      # above) already gates on.
+      - name: configure (with coverage)
+        run: |
+          ./configure --prefix="${GITHUB_WORKSPACE}/_install" \
+            CFLAGS="-O0 -g --coverage" \
+            LDFLAGS="--coverage"
+
+      - name: make
+        run: make -j"$(nproc)"
+
+      - name: make install
+        run: make install
+
+      - name: Run FS API tests
+        env:
+          ALTFS_PREFIX: ${{ github.workspace }}/_install
+        run: bash tests/fsapi/run.sh -v
+
+      - name: Run scenario tests
+        env:
+          ALTFS_PREFIX: ${{ github.workspace }}/_install
+        run: bash tests/scenarios/run.sh -v
+
+      - name: Collect coverage
+        run: |
+          lcov --capture --directory . --output-file coverage.info \
+               --ignore-errors source,gcov
+          lcov --remove coverage.info \
+               '/usr/*' '*/tests/*' \
+               --output-file coverage.info \
+               --ignore-errors unused
+          lcov --list coverage.info
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-info
+          path: coverage.info
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage.info
+          fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,10 @@ rpm/BUILD/
 rpm/BUILDROOT/
 rpm/RPMS/
 rpm/SRPMS/
+# Python test artifacts
+__pycache__/
+*.pyc
+.pytest_cache/
 # Files for development
 GPATH
 GRTAGS

--- a/src/libltfs/ltfs_fsops.c
+++ b/src/libltfs/ltfs_fsops.c
@@ -477,6 +477,14 @@ int ltfs_fsops_unlink(const char *path, ltfs_file_id *id, struct ltfs_volume *vo
 	}
 	parent = d->parent;
 
+	/* parent->meta_lock is released unconditionally at `out:` (via
+	 * fs_release_dentry_unlocked), so it must be acquired before any
+	 * goto out. Acquiring it later left the early-bail paths
+	 * (WORM, DIRNOTEMPTY) releasing a lock that was never held,
+	 * corrupting the rwlock and deadlocking later operations on the
+	 * same parent. */
+	acquirewrite_mrsw(&parent->meta_lock);
+
 	if (parent->is_immutable || parent->is_appendonly) {
 		ltfsmsg(ALI0040E, "unlink: parent is WORM");
 		ret = -LTFS_WORM_ENABLED;
@@ -499,7 +507,6 @@ int ltfs_fsops_unlink(const char *path, ltfs_file_id *id, struct ltfs_volume *vo
 			goto out;
 	}
 
-	acquirewrite_mrsw(&parent->meta_lock);
 	acquirewrite_mrsw(&d->meta_lock);
 
 	if (dcache_initialized(vol)) {

--- a/tests/common/altfs.py
+++ b/tests/common/altfs.py
@@ -1,0 +1,65 @@
+"""Format / mount / umount helpers for the altfs file backend.
+
+Used by the module-scoped mounted_tape fixture in tests/conftest.py
+and by tests that need to cycle through multiple mounts (e.g. the
+index round-trip test). LTFS tape serial is fixed-width: exactly 6
+characters.
+"""
+
+import os
+import re
+import subprocess
+import time
+
+_READY_TIMEOUT = 5.0
+_POLL_INTERVAL = 0.1
+
+
+def _wait_until(predicate, timeout=_READY_TIMEOUT):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(_POLL_INTERVAL)
+    return False
+
+
+def format_tape(tape_dir, serial="TEST00", label="test"):
+    subprocess.run(
+        ["mkaltfs", "-e", "file", "-d", str(tape_dir),
+         "-s", serial, "-n", label, "-f"],
+        check=True,
+    )
+
+
+def mount_tape(tape_dir, mnt, sync_type="unmount"):
+    subprocess.run(
+        ["altfs",
+         "-o", "tape_backend=file",
+         "-o", f"devname={tape_dir}",
+         "-o", f"sync_type={sync_type}",
+         str(mnt)],
+        check=True,
+    )
+    if not _wait_until(lambda: os.path.ismount(mnt)):
+        raise RuntimeError(f"FUSE mount did not become ready: {mnt}")
+
+
+def umount_tape(mnt):
+    subprocess.run(["fusermount", "-u", str(mnt)], check=False)
+    _wait_until(lambda: not os.path.ismount(mnt))
+    # fusermount returns as soon as the kernel detaches the mount,
+    # but the altfs daemon still has its final index flush to do
+    # (sync_type=unmount writes the index on the way out). Tests
+    # that read the tape directory after umount race against that
+    # flush — most visibly, altfs unlink+creates record files, so
+    # an os.listdir hit can vanish a millisecond later. Wait for
+    # the altfs process serving this mount to actually exit.
+    pattern = f"altfs.*{re.escape(str(mnt))}$"
+    _wait_until(
+        lambda: subprocess.call(
+            ["pgrep", "-f", pattern],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        ) != 0
+    )

--- a/tests/common/helpers.py
+++ b/tests/common/helpers.py
@@ -7,9 +7,13 @@ from pathlib import Path
 
 _RECORD_RE = re.compile(r"^(\d+)_(\d+)_R$")
 
+# On Linux, LTFS xattrs are exposed under the user.* namespace; the kernel
+# only lets unprivileged callers see/set xattrs in that namespace.
+_LINUX_NS = "user."
+
 
 def get_xattr(path, name):
-    return os.getxattr(os.fspath(path), name).decode("utf-8")
+    return os.getxattr(os.fspath(path), _LINUX_NS + name).decode("utf-8")
 
 
 def get_xattr_int(path, name):
@@ -17,7 +21,7 @@ def get_xattr_int(path, name):
 
 
 def set_xattr(path, name, value):
-    os.setxattr(os.fspath(path), name, value.encode("utf-8"))
+    os.setxattr(os.fspath(path), _LINUX_NS + name, value.encode("utf-8"))
 
 
 def full_sync(mnt, reason="test"):

--- a/tests/common/helpers.py
+++ b/tests/common/helpers.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+
+_RECORD_RE = re.compile(r"^(\d+)_(\d+)_R$")
+
+
+def get_xattr(path, name):
+    return os.getxattr(os.fspath(path), name).decode("utf-8")
+
+
+def get_xattr_int(path, name):
+    return int(get_xattr(path, name))
+
+
+def set_xattr(path, name, value):
+    os.setxattr(os.fspath(path), name, value.encode("utf-8"))
+
+
+def full_sync(mnt, reason="test"):
+    set_xattr(mnt, "ltfs.vendor.Aurora.FullSync", reason)
+
+
+def list_records(tape_dir):
+    ip, dp = [], []
+    for name in os.listdir(tape_dir):
+        m = _RECORD_RE.match(name)
+        if not m:
+            continue
+        partition, block = int(m.group(1)), int(m.group(2))
+        path = Path(tape_dir) / name
+        if partition == 0:
+            ip.append((block, path))
+        elif partition == 1:
+            dp.append((block, path))
+    ip.sort()
+    dp.sort()
+    return [p for _, p in ip], [p for _, p in dp]

--- a/tests/common/index.py
+++ b/tests/common/index.py
@@ -1,0 +1,49 @@
+"""Independent inspection of LTFS index XML records on the file backend.
+
+These helpers parse the XML with Python's stdlib (xml.etree), which
+shares no code with altfs's libxml2-based parser. A structural bug
+that altfs's writer + reader both round-trip cleanly can still be
+caught here.
+"""
+
+import os
+import re
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+_IP_RECORD_RE = re.compile(r"^0_(\d+)_R$")
+
+
+def find_latest_index_record(tape_dir):
+    """Path to the highest-numbered IP record file whose content begins
+    with an <ltfsindex> element (skips the VOL1 label and <ltfslabel>)."""
+    candidates = []
+    for name in os.listdir(tape_dir):
+        m = _IP_RECORD_RE.match(name)
+        if not m:
+            continue
+        path = Path(tape_dir) / name
+        if b"<ltfsindex" in path.read_bytes()[:64]:
+            candidates.append((int(m.group(1)), path))
+    if not candidates:
+        raise RuntimeError(f"no ltfsindex record found in {tape_dir}")
+    candidates.sort()
+    return candidates[-1][1]
+
+
+def parse_latest_index(tape_dir):
+    """Parse the latest IP index XML and return the root element."""
+    return ET.parse(find_latest_index_record(tape_dir)).getroot()
+
+
+def find_entries_by_name(root, names):
+    """Walk all <file> and <directory> entries and return a dict mapping
+    each matched name → element. Unmatched names are simply absent."""
+    found = {}
+    target = set(names)
+    for elem in root.iter():
+        if elem.tag in ("file", "directory"):
+            name_el = elem.find("name")
+            if name_el is not None and name_el.text in target:
+                found[name_el.text] = elem
+    return found

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,26 +1,13 @@
 from __future__ import annotations
 
 import os
-import subprocess
 import sys
-import time
 
 import pytest
 
 sys.path.insert(0, os.path.dirname(__file__))
 
-
-_READY_TIMEOUT = 5.0
-_POLL_INTERVAL = 0.1
-
-
-def _wait_until(predicate, timeout):
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        if predicate():
-            return True
-        time.sleep(_POLL_INTERVAL)
-    return False
+from common.altfs import format_tape, mount_tape, umount_tape
 
 
 @pytest.fixture(scope="module")
@@ -31,24 +18,9 @@ def mounted_tape(tmp_path_factory):
     tape_dir.mkdir()
     mnt_dir.mkdir()
 
-    subprocess.run(
-        ["mkaltfs", "-e", "file", "-d", str(tape_dir),
-         "-s", "TEST00", "-n", "test", "-f"],
-        check=True,
-    )
-    subprocess.run(
-        ["altfs",
-         "-o", "tape_backend=file",
-         "-o", f"devname={tape_dir}",
-         "-o", "sync_type=unmount",
-         str(mnt_dir)],
-        check=True,
-    )
-    if not _wait_until(lambda: os.path.ismount(mnt_dir), _READY_TIMEOUT):
-        raise RuntimeError(f"FUSE mount did not become ready: {mnt_dir}")
-
+    format_tape(tape_dir)
+    mount_tape(tape_dir, mnt_dir)
     try:
         yield mnt_dir
     finally:
-        subprocess.run(["fusermount", "-u", str(mnt_dir)], check=False)
-        _wait_until(lambda: not os.path.ismount(mnt_dir), _READY_TIMEOUT)
+        umount_tape(mnt_dir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+
+import pytest
+
+
+_READY_TIMEOUT = 5.0
+_POLL_INTERVAL = 0.1
+
+
+def _wait_until(predicate, timeout):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(_POLL_INTERVAL)
+    return False
+
+
+@pytest.fixture(scope="module")
+def mounted_tape(tmp_path_factory):
+    base = tmp_path_factory.mktemp("altfs")
+    tape_dir = base / "tape"
+    mnt_dir = base / "mnt"
+    tape_dir.mkdir()
+    mnt_dir.mkdir()
+
+    subprocess.run(
+        ["mkaltfs", "-e", "file", "-d", str(tape_dir),
+         "-s", "TEST00", "-n", "test", "-f"],
+        check=True,
+    )
+    subprocess.run(
+        ["altfs",
+         "-o", "tape_backend=file",
+         "-o", f"devname={tape_dir}",
+         "-o", "sync_type=unmount",
+         str(mnt_dir)],
+        check=True,
+    )
+    if not _wait_until(lambda: os.path.ismount(mnt_dir), _READY_TIMEOUT):
+        raise RuntimeError(f"FUSE mount did not become ready: {mnt_dir}")
+
+    try:
+        yield mnt_dir
+    finally:
+        subprocess.run(["fusermount", "-u", str(mnt_dir)], check=False)
+        _wait_until(lambda: not os.path.ismount(mnt_dir), _READY_TIMEOUT)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 import time
 
 import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
 
 
 _READY_TIMEOUT = 5.0

--- a/tests/fsapi/run.sh
+++ b/tests/fsapi/run.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+: "${ALTFS_PREFIX:=/workspaces/altfs}"
+export PATH="${ALTFS_PREFIX}/bin:${PATH}"
+export LD_LIBRARY_PATH="${ALTFS_PREFIX}/lib:${LD_LIBRARY_PATH:-}"
+
+exec pytest "${SCRIPT_DIR}" "$@"

--- a/tests/fsapi/test_chmod.py
+++ b/tests/fsapi/test_chmod.py
@@ -1,0 +1,53 @@
+"""LTFS chmod honors only writability — the chmod request is collapsed
+to a single readonly flag (any write bit set → writable). Mode bits
+returned by stat are controlled by mount-time file_mode/dir_mode, not
+by chmod. See https://www.ibm.com/docs/en/storage-archive-sde/2.4.8?topic=tips-file-permissions
+"""
+
+import stat
+
+import pytest
+
+
+def test_chmod_no_write_bits_makes_readonly(mounted_tape):
+    p = mounted_tape / "ro.txt"
+    p.write_text("payload")
+    p.chmod(0o444)
+    with pytest.raises(PermissionError):
+        open(p, "w")
+
+
+def test_chmod_with_write_bit_keeps_writable(mounted_tape):
+    p = mounted_tape / "rw.txt"
+    p.write_text("payload")
+    p.chmod(0o644)
+    with open(p, "w") as f:
+        f.write("updated")
+    assert p.read_text() == "updated"
+
+
+def test_chmod_readonly_then_writable_round_trip(mounted_tape):
+    p = mounted_tape / "round.txt"
+    p.write_text("v1")
+    p.chmod(0o444)
+    with pytest.raises(PermissionError):
+        open(p, "w")
+    p.chmod(0o644)
+    with open(p, "w") as f:
+        f.write("v2")
+    assert p.read_text() == "v2"
+
+
+def test_chmod_only_affects_writability_not_mode_bits(mounted_tape):
+    p = mounted_tape / "mode_check.txt"
+    p.write_text("x")
+    p.chmod(0o644)
+    m1 = stat.S_IMODE(p.stat().st_mode)
+    p.chmod(0o600)
+    m2 = stat.S_IMODE(p.stat().st_mode)
+    assert m1 == m2
+
+
+def test_chmod_missing_raises(mounted_tape):
+    with pytest.raises(FileNotFoundError):
+        (mounted_tape / "chmod_missing").chmod(0o644)

--- a/tests/fsapi/test_chown.py
+++ b/tests/fsapi/test_chown.py
@@ -1,0 +1,23 @@
+"""LTFS does not model per-file ownership at all: the on-tape XML
+index has no uid/gid field. Tapes are portable, and a numeric uid
+stored on tape would not refer to the same person on a different
+system — so per-file ownership isn't just unimplemented, it would be
+semantically meaningless across the cartridge's lifetime. Possession
+of the tape is the access boundary instead.
+
+ltfs_fuse_chown therefore returns success unconditionally and the
+owner reported by stat — sourced from the mount-time uid/gid options
+of the current host — never changes.
+"""
+
+import os
+
+
+def test_chown_is_a_noop_to_self(mounted_tape):
+    p = mounted_tape / "chown_noop.txt"
+    p.write_text("x")
+    uid, gid = os.getuid(), os.getgid()
+    before = p.stat()
+    os.chown(p, uid, gid)
+    after = p.stat()
+    assert (before.st_uid, before.st_gid) == (after.st_uid, after.st_gid)

--- a/tests/fsapi/test_explicit_sync.py
+++ b/tests/fsapi/test_explicit_sync.py
@@ -1,0 +1,13 @@
+from common.helpers import full_sync, get_xattr, get_xattr_int
+
+
+def test_full_sync_increments_generation(mounted_tape):
+    g0 = get_xattr_int(mounted_tape, "ltfs.indexGeneration")
+    loc0 = get_xattr(mounted_tape, "ltfs.indexLocation")
+
+    (mounted_tape / "fs_sync.txt").write_text("payload")
+
+    full_sync(mounted_tape, reason="test_full_sync_increments_generation")
+
+    assert get_xattr_int(mounted_tape, "ltfs.indexGeneration") == g0 + 1
+    assert get_xattr(mounted_tape, "ltfs.indexLocation") != loc0

--- a/tests/fsapi/test_index_roundtrip.py
+++ b/tests/fsapi/test_index_roundtrip.py
@@ -1,0 +1,81 @@
+"""Round-trip + independent index validation.
+
+The module-scoped mounted_tape fixture only exercises altfs's
+read/write of the index once per test file. This test cycles
+format → mount → write → umount → independent XML inspection →
+re-mount → verify → umount, so it covers both that the on-tape
+index reconstructs into the same view AND that the XML matches
+what we wrote, verified by a parser (stdlib xml.etree) that
+shares no code with altfs.
+"""
+
+import pytest
+
+from common.altfs import format_tape, mount_tape, umount_tape
+from common.helpers import get_xattr, set_xattr
+from common.index import find_entries_by_name, parse_latest_index
+
+
+_BIG_LEN = 700 * 1024  # > 1 × 512 KiB block, exercises multi-extent
+_BIG_BYTE = b"X"
+
+
+def test_index_roundtrip(tmp_path_factory):
+    base = tmp_path_factory.mktemp("altfs-roundtrip")
+    tape_dir = base / "tape"
+    mnt = base / "mnt"
+    tape_dir.mkdir()
+    mnt.mkdir()
+
+    format_tape(tape_dir, serial="ROUND0", label="roundtrip")
+
+    # Round 1: populate with diverse content
+    mount_tape(tape_dir, mnt)
+    try:
+        (mnt / "regular.txt").write_text("payload-A")
+        (mnt / "subdir").mkdir()
+        (mnt / "subdir" / "inner.txt").write_text("inside")
+        set_xattr(mnt / "regular.txt", "test.tag", "v1")
+        (mnt / "ro.txt").write_text("ro content")
+        (mnt / "ro.txt").chmod(0o444)
+        (mnt / "big.bin").write_bytes(_BIG_BYTE * _BIG_LEN)
+        (mnt / "link").symlink_to(mnt / "regular.txt")
+    finally:
+        umount_tape(mnt)
+
+    # Independent inspection of what altfs wrote to tape.
+    root = parse_latest_index(tape_dir)
+    assert root.tag == "ltfsindex"
+    assert int(root.find("generationnumber").text) >= 2
+
+    entries = find_entries_by_name(
+        root,
+        {"regular.txt", "subdir", "inner.txt", "ro.txt", "big.bin", "link"},
+    )
+    assert set(entries) == {"regular.txt", "subdir", "inner.txt", "ro.txt", "big.bin", "link"}
+
+    assert int(entries["regular.txt"].find("length").text) == len("payload-A")
+    assert int(entries["big.bin"].find("length").text) == _BIG_LEN
+    assert entries["ro.txt"].find("readonly").text == "true"
+    assert entries["link"].find("symlink") is not None
+
+    xattrs = {
+        x.find("key").text: x.find("value").text
+        for x in entries["regular.txt"].iter("xattr")
+    }
+    assert xattrs.get("test.tag") == "v1"
+
+    # Round 2: re-mount and verify everything reads back through altfs.
+    mount_tape(tape_dir, mnt)
+    try:
+        assert (mnt / "regular.txt").read_text() == "payload-A"
+        assert (mnt / "subdir" / "inner.txt").read_text() == "inside"
+        assert (mnt / "ro.txt").read_text() == "ro content"
+        assert (mnt / "big.bin").stat().st_size == _BIG_LEN
+        assert (mnt / "big.bin").read_bytes() == _BIG_BYTE * _BIG_LEN
+        assert (mnt / "link").read_text() == "payload-A"
+        assert get_xattr(mnt / "regular.txt", "test.tag") == "v1"
+        with pytest.raises(PermissionError):
+            open(mnt / "ro.txt", "w")
+    finally:
+        umount_tape(mnt)

--- a/tests/fsapi/test_io_block_boundary.py
+++ b/tests/fsapi/test_io_block_boundary.py
@@ -1,0 +1,86 @@
+"""I/O at and across the 512 KiB block boundary.
+
+The unified I/O scheduler aggregates FUSE-side requests into
+512 KiB records on tape, so write/read patterns that hit, miss,
+or cross that boundary exercise the stitching logic that pure
+small-file tests don't.
+"""
+
+import os
+
+import pytest
+
+
+_BLOCK = 524288
+
+
+def _payload(n):
+    return os.urandom(n)
+
+
+@pytest.mark.parametrize(
+    "size",
+    [
+        1,
+        4096,
+        _BLOCK - 1,
+        _BLOCK,
+        _BLOCK + 1,
+        _BLOCK + _BLOCK // 2,
+        2 * _BLOCK,
+        2 * _BLOCK + 100 * 1024,
+        3 * _BLOCK + 1,
+    ],
+)
+def test_write_then_read_roundtrip(mounted_tape, size):
+    p = mounted_tape / f"io_{size}.bin"
+    data = _payload(size)
+    p.write_bytes(data)
+    assert p.stat().st_size == size
+    assert p.read_bytes() == data
+
+
+def test_split_writes_cross_block_boundary(mounted_tape):
+    p = mounted_tape / "io_split.bin"
+    first = _payload(_BLOCK - 100)
+    spanning = _payload(200)
+    third = _payload(_BLOCK)
+
+    with open(p, "wb") as f:
+        f.write(first)
+        f.write(spanning)
+        f.write(third)
+
+    expected = first + spanning + third
+    assert p.stat().st_size == len(expected)
+    assert p.read_bytes() == expected
+
+
+def test_pwrite_pread_across_block_boundary(mounted_tape):
+    p = mounted_tape / "io_pwrite.bin"
+    p.write_bytes(b"\x00" * (2 * _BLOCK))
+    payload = _payload(2000)
+    offset = 512000
+
+    with open(p, "r+b") as f:
+        os.pwrite(f.fileno(), payload, offset)
+
+    with open(p, "rb") as f:
+        assert os.pread(f.fileno(), 2000, offset) == payload
+        assert os.pread(f.fileno(), 100, offset - 100) == b"\x00" * 100
+        assert os.pread(f.fileno(), 100, offset + 2000) == b"\x00" * 100
+
+
+def test_pwrite_extending_creates_zero_gap(mounted_tape):
+    p = mounted_tape / "io_pwrite_extend.bin"
+    p.write_bytes(b"\x00" * 100)
+    payload = _payload(_BLOCK)
+
+    with open(p, "r+b") as f:
+        os.pwrite(f.fileno(), payload, _BLOCK)
+
+    assert p.stat().st_size == 2 * _BLOCK
+    with open(p, "rb") as f:
+        gap = os.pread(f.fileno(), _BLOCK - 100, 100)
+        assert gap == b"\x00" * (_BLOCK - 100)
+        assert os.pread(f.fileno(), _BLOCK, _BLOCK) == payload

--- a/tests/fsapi/test_mkdir.py
+++ b/tests/fsapi/test_mkdir.py
@@ -1,0 +1,64 @@
+import os
+import stat
+
+import pytest
+
+
+def test_mkdir_creates_directory(mounted_tape):
+    d = mounted_tape / "newdir"
+    d.mkdir()
+    assert stat.S_ISDIR(d.stat().st_mode)
+
+
+def test_mkdir_existing_raises(mounted_tape):
+    d = mounted_tape / "dup"
+    d.mkdir()
+    with pytest.raises(FileExistsError):
+        d.mkdir()
+
+
+def test_rmdir_empty_directory(mounted_tape):
+    d = mounted_tape / "empty_dir"
+    d.mkdir()
+    d.rmdir()
+    assert not d.exists()
+
+
+def test_rmdir_nonempty_raises(mounted_tape):
+    d = mounted_tape / "nonempty"
+    d.mkdir()
+    (d / "file.txt").write_text("x")
+    with pytest.raises(OSError):
+        d.rmdir()
+
+
+def test_rmdir_missing_raises(mounted_tape):
+    with pytest.raises(FileNotFoundError):
+        (mounted_tape / "does_not_exist").rmdir()
+
+
+def test_listdir_empty_after_mkdir(mounted_tape):
+    d = mounted_tape / "ls_empty"
+    d.mkdir()
+    assert os.listdir(d) == []
+
+
+def test_listdir_returns_all_entries(mounted_tape):
+    d = mounted_tape / "ls_entries"
+    d.mkdir()
+    (d / "a.txt").write_text("a")
+    (d / "b.txt").write_text("b")
+    (d / "sub").mkdir()
+    assert set(os.listdir(d)) == {"a.txt", "b.txt", "sub"}
+
+
+def test_nested_mkdir(mounted_tape):
+    a = mounted_tape / "nested_a"
+    a.mkdir()
+    b = a / "b"
+    b.mkdir()
+    c = b / "c"
+    c.mkdir()
+    assert c.is_dir()
+    assert os.listdir(a) == ["b"]
+    assert os.listdir(b) == ["c"]

--- a/tests/fsapi/test_rename.py
+++ b/tests/fsapi/test_rename.py
@@ -1,0 +1,51 @@
+import pytest
+
+
+def test_rename_within_dir(mounted_tape):
+    src = mounted_tape / "within_src.txt"
+    dst = mounted_tape / "within_dst.txt"
+    src.write_text("payload")
+    src.rename(dst)
+    assert not src.exists()
+    assert dst.read_text() == "payload"
+
+
+def test_rename_across_dirs(mounted_tape):
+    sd = mounted_tape / "rn_from"
+    td = mounted_tape / "rn_to"
+    sd.mkdir()
+    td.mkdir()
+    src = sd / "f.txt"
+    dst = td / "f.txt"
+    src.write_text("hi")
+    src.rename(dst)
+    assert not src.exists()
+    assert dst.read_text() == "hi"
+
+
+def test_rename_directory_with_contents(mounted_tape):
+    d = mounted_tape / "rn_dir"
+    d.mkdir()
+    (d / "inner.txt").write_text("inside")
+    moved = mounted_tape / "rn_dir_moved"
+    d.rename(moved)
+    assert not d.exists()
+    assert (moved / "inner.txt").read_text() == "inside"
+
+
+def test_rename_overwrites_existing_file(mounted_tape):
+    src = mounted_tape / "ow_src.txt"
+    dst = mounted_tape / "ow_dst.txt"
+    src.write_text("new")
+    dst.write_text("old")
+    src.rename(dst)
+    assert not src.exists()
+    assert dst.read_text() == "new"
+
+
+def test_rename_to_missing_parent_raises(mounted_tape):
+    src = mounted_tape / "missing_parent_src.txt"
+    src.write_text("x")
+    bad = mounted_tape / "no_such_dir" / "x.txt"
+    with pytest.raises(FileNotFoundError):
+        src.rename(bad)

--- a/tests/fsapi/test_rename_error_paths.py
+++ b/tests/fsapi/test_rename_error_paths.py
@@ -1,0 +1,68 @@
+import errno
+
+import pytest
+
+
+def _sentinel(parent, tag):
+    """Prove the FS is still responsive on `parent` after an expected
+    failure. Catches the symptom that uncovered the unlink bug fixed
+    in 0338bbc: a stuck rwlock that deadlocks the next op on the same
+    parent."""
+    d = parent / f"_sentinel_{tag}"
+    d.mkdir()
+    assert d.is_dir()
+
+
+def test_rename_source_missing(mounted_tape):
+    with pytest.raises(FileNotFoundError):
+        (mounted_tape / "miss_src").rename(mounted_tape / "miss_dst")
+    _sentinel(mounted_tape, "src_missing")
+
+
+def test_rename_dir_onto_nonempty_dir(mounted_tape):
+    src = mounted_tape / "ne_src_dir"
+    src.mkdir()
+    dst = mounted_tape / "ne_dst_dir"
+    dst.mkdir()
+    (dst / "occupant.txt").write_text("x")
+    with pytest.raises(OSError) as ei:
+        src.rename(dst)
+    assert ei.value.errno in (errno.ENOTEMPTY, errno.EEXIST)
+    _sentinel(mounted_tape, "ne_dir")
+
+
+def test_rename_dir_onto_file(mounted_tape):
+    src = mounted_tape / "tm_dir"
+    src.mkdir()
+    dst = mounted_tape / "tm_file"
+    dst.write_text("payload")
+    with pytest.raises(OSError):
+        src.rename(dst)
+    _sentinel(mounted_tape, "dir_over_file")
+
+
+def test_rename_file_onto_dir(mounted_tape):
+    src = mounted_tape / "tm_src_file"
+    src.write_text("payload")
+    dst = mounted_tape / "tm_dir2"
+    dst.mkdir()
+    with pytest.raises(OSError):
+        src.rename(dst)
+    _sentinel(mounted_tape, "file_over_dir")
+
+
+def test_rename_into_own_subdirectory(mounted_tape):
+    parent = mounted_tape / "loop_a"
+    parent.mkdir()
+    child = parent / "b"
+    with pytest.raises(OSError):
+        parent.rename(child)
+    _sentinel(mounted_tape, "loop")
+
+
+def test_rename_to_self_is_noop(mounted_tape):
+    p = mounted_tape / "self_rename.txt"
+    p.write_text("payload")
+    p.rename(p)
+    assert p.read_text() == "payload"
+    _sentinel(mounted_tape, "self")

--- a/tests/fsapi/test_smoke.py
+++ b/tests/fsapi/test_smoke.py
@@ -1,0 +1,4 @@
+def test_open_write_read(mounted_tape):
+    p = mounted_tape / "hello.txt"
+    p.write_text("hello world")
+    assert p.read_text() == "hello world"

--- a/tests/fsapi/test_stat.py
+++ b/tests/fsapi/test_stat.py
@@ -1,0 +1,54 @@
+import os
+import stat
+import time
+
+import pytest
+
+
+def test_stat_regular_file(mounted_tape):
+    p = mounted_tape / "stat_reg.txt"
+    p.write_text("hello")
+    st = p.stat()
+    assert stat.S_ISREG(st.st_mode)
+    assert st.st_size == 5
+    assert st.st_ino != 0
+
+
+def test_stat_directory(mounted_tape):
+    d = mounted_tape / "stat_dir"
+    d.mkdir()
+    st = d.stat()
+    assert stat.S_ISDIR(st.st_mode)
+
+
+def test_stat_missing_raises(mounted_tape):
+    with pytest.raises(FileNotFoundError):
+        (mounted_tape / "stat_missing").stat()
+
+
+def test_fstat_open_file(mounted_tape):
+    p = mounted_tape / "fstat.txt"
+    p.write_text("payload")
+    with open(p, "rb") as f:
+        st = os.fstat(f.fileno())
+    assert stat.S_ISREG(st.st_mode)
+    assert st.st_size == 7
+
+
+def test_stat_size_reflects_appends(mounted_tape):
+    p = mounted_tape / "grow_size.txt"
+    p.write_bytes(b"abc")
+    assert p.stat().st_size == 3
+    with open(p, "ab") as f:
+        f.write(b"defgh")
+    assert p.stat().st_size == 8
+
+
+def test_stat_mtime_updates_on_write(mounted_tape):
+    p = mounted_tape / "mtime.txt"
+    p.write_text("v1")
+    t0 = p.stat().st_mtime_ns
+    time.sleep(0.02)
+    p.write_text("v2")
+    t1 = p.stat().st_mtime_ns
+    assert t1 > t0

--- a/tests/fsapi/test_symlink.py
+++ b/tests/fsapi/test_symlink.py
@@ -1,0 +1,44 @@
+import os
+import stat
+
+import pytest
+
+
+def test_symlink_to_existing_file_resolves(mounted_tape):
+    target = mounted_tape / "sl_target.txt"
+    target.write_text("payload")
+    link = mounted_tape / "sl_link"
+    link.symlink_to(target)
+    assert link.read_text() == "payload"
+
+
+def test_readlink_returns_stored_target(mounted_tape):
+    target = mounted_tape / "sl_readlink_target.txt"
+    target.write_text("x")
+    link = mounted_tape / "sl_readlink"
+    link.symlink_to(target)
+    assert os.readlink(link) == str(target)
+
+
+def test_lstat_reports_symlink_stat_follows(mounted_tape):
+    target = mounted_tape / "sl_stat_target.txt"
+    target.write_text("x")
+    link = mounted_tape / "sl_stat_link"
+    link.symlink_to(target)
+    assert stat.S_ISLNK(link.lstat().st_mode)
+    assert stat.S_ISREG(link.stat().st_mode)
+
+
+def test_dangling_symlink(mounted_tape):
+    link = mounted_tape / "sl_dangling"
+    link.symlink_to(mounted_tape / "no_such_target")
+    assert stat.S_ISLNK(link.lstat().st_mode)
+    with pytest.raises(FileNotFoundError):
+        link.stat()
+
+
+def test_readlink_on_regular_file_raises(mounted_tape):
+    p = mounted_tape / "sl_regular.txt"
+    p.write_text("x")
+    with pytest.raises(OSError):
+        os.readlink(p)

--- a/tests/fsapi/test_truncate.py
+++ b/tests/fsapi/test_truncate.py
@@ -1,0 +1,55 @@
+import os
+
+import pytest
+
+
+def test_truncate_to_zero(mounted_tape):
+    p = mounted_tape / "t_zero.txt"
+    p.write_bytes(b"abcdefghij")
+    os.truncate(p, 0)
+    assert p.stat().st_size == 0
+    assert p.read_bytes() == b""
+
+
+def test_truncate_shrink(mounted_tape):
+    p = mounted_tape / "t_shrink.txt"
+    p.write_bytes(b"abcdefghij")
+    os.truncate(p, 5)
+    assert p.stat().st_size == 5
+    assert p.read_bytes() == b"abcde"
+
+
+def test_truncate_grow_fills_with_zeros(mounted_tape):
+    p = mounted_tape / "t_grow.txt"
+    p.write_bytes(b"abcdefghij")
+    os.truncate(p, 20)
+    assert p.stat().st_size == 20
+    assert p.read_bytes() == b"abcdefghij" + b"\x00" * 10
+
+
+def test_truncate_same_size_is_noop(mounted_tape):
+    p = mounted_tape / "t_same.txt"
+    p.write_bytes(b"hello")
+    os.truncate(p, 5)
+    assert p.stat().st_size == 5
+    assert p.read_bytes() == b"hello"
+
+
+def test_ftruncate_via_fd(mounted_tape):
+    p = mounted_tape / "t_ftrunc.txt"
+    p.write_bytes(b"helloworld")
+    with open(p, "r+b") as f:
+        os.ftruncate(f.fileno(), 5)
+    assert p.read_bytes() == b"hello"
+
+
+def test_truncate_missing_raises(mounted_tape):
+    with pytest.raises(FileNotFoundError):
+        os.truncate(mounted_tape / "t_missing.txt", 10)
+
+
+def test_truncate_directory_raises(mounted_tape):
+    d = mounted_tape / "t_dir"
+    d.mkdir()
+    with pytest.raises(OSError):
+        os.truncate(d, 0)

--- a/tests/fsapi/test_utime.py
+++ b/tests/fsapi/test_utime.py
@@ -1,0 +1,37 @@
+import os
+
+import pytest
+
+
+def test_utime_sets_mtime_and_atime(mounted_tape):
+    p = mounted_tape / "ut_basic.txt"
+    p.write_text("payload")
+    target_atime = 1_600_000_000.5
+    target_mtime = 1_600_000_100.25
+    os.utime(p, (target_atime, target_mtime))
+    st = p.stat()
+    assert st.st_atime == target_atime
+    assert st.st_mtime == target_mtime
+
+
+def test_utime_with_none_advances_to_now(mounted_tape):
+    p = mounted_tape / "ut_now.txt"
+    p.write_text("payload")
+    os.utime(p, (1_500_000_000.0, 1_500_000_000.0))
+    old = p.stat().st_mtime
+    os.utime(p, None)
+    new = p.stat().st_mtime
+    assert new > old
+
+
+def test_utime_preserves_size_and_content(mounted_tape):
+    p = mounted_tape / "ut_preserve.txt"
+    p.write_text("payload")
+    os.utime(p, (1_600_000_000.0, 1_600_000_100.0))
+    assert p.read_text() == "payload"
+    assert p.stat().st_size == len("payload")
+
+
+def test_utime_missing_raises(mounted_tape):
+    with pytest.raises(FileNotFoundError):
+        os.utime(mounted_tape / "ut_missing.txt", (1_600_000_000.0, 1_600_000_000.0))

--- a/tests/fsapi/test_xattr.py
+++ b/tests/fsapi/test_xattr.py
@@ -1,8 +1,11 @@
+import base64
 import os
 
 import pytest
 
+from common.altfs import format_tape, mount_tape, umount_tape
 from common.helpers import get_xattr, set_xattr
+from common.index import find_entries_by_name, parse_latest_index
 
 _USER_NS = "user."
 
@@ -67,3 +70,45 @@ def test_xattr_survives_after_writes_to_file(mounted_tape):
     set_xattr(p, "test.persist", "tag")
     p.write_text("v2-longer-content")
     assert get_xattr(p, "test.persist") == "tag"
+
+
+def test_unprintable_xattr_value_is_base64_on_tape(tmp_path_factory):
+    """An xattr value that contains bytes pathname_validate_xattr_value
+    rejects (NUL, 0x7f, high bytes, etc.) must be serialized as
+    <value type="base64">...</value> in the index XML, and must
+    round-trip back to the original bytes through a re-mount."""
+    base = tmp_path_factory.mktemp("altfs-xattr-bin")
+    tape = base / "tape"
+    mnt = base / "mnt"
+    tape.mkdir()
+    mnt.mkdir()
+    format_tape(tape, serial="XATTRB", label="xattr-bin")
+
+    binary_value = b"\x00\x01\x02\x7f\x80\xfe\xff"
+    qname = _USER_NS + "test.binary"
+
+    mount_tape(tape, mnt)
+    try:
+        f = mnt / "binxattr.txt"
+        f.write_text("payload")
+        os.setxattr(os.fspath(f), qname, binary_value)
+    finally:
+        umount_tape(mnt)
+
+    root = parse_latest_index(tape)
+    entries = find_entries_by_name(root, {"binxattr.txt"})
+    file_el = entries["binxattr.txt"]
+    value_el = None
+    for xattr in file_el.iter("xattr"):
+        if xattr.find("key").text == "test.binary":
+            value_el = xattr.find("value")
+            break
+    assert value_el is not None, "test.binary xattr not present in index"
+    assert value_el.get("type") == "base64"
+    assert base64.b64decode(value_el.text) == binary_value
+
+    mount_tape(tape, mnt)
+    try:
+        assert os.getxattr(os.fspath(mnt / "binxattr.txt"), qname) == binary_value
+    finally:
+        umount_tape(mnt)

--- a/tests/fsapi/test_xattr.py
+++ b/tests/fsapi/test_xattr.py
@@ -1,0 +1,69 @@
+import os
+
+import pytest
+
+from common.helpers import get_xattr, set_xattr
+
+_USER_NS = "user."
+
+
+def test_setxattr_getxattr_roundtrip(mounted_tape):
+    p = mounted_tape / "xa_basic.txt"
+    p.write_text("payload")
+    set_xattr(p, "test.basic", "hello")
+    assert get_xattr(p, "test.basic") == "hello"
+
+
+def test_listxattr_includes_set_attribute(mounted_tape):
+    p = mounted_tape / "xa_list.txt"
+    p.write_text("payload")
+    set_xattr(p, "test.a", "1")
+    set_xattr(p, "test.b", "2")
+    names = set(os.listxattr(p))
+    assert {_USER_NS + "test.a", _USER_NS + "test.b"} <= names
+
+
+def test_removexattr_deletes_attribute(mounted_tape):
+    p = mounted_tape / "xa_rm.txt"
+    p.write_text("payload")
+    set_xattr(p, "test.del", "x")
+    os.removexattr(p, _USER_NS + "test.del")
+    with pytest.raises(OSError):
+        get_xattr(p, "test.del")
+
+
+def test_getxattr_missing_raises(mounted_tape):
+    p = mounted_tape / "xa_missing.txt"
+    p.write_text("payload")
+    with pytest.raises(OSError):
+        get_xattr(p, "test.never_set")
+
+
+def test_setxattr_replace_on_missing_raises(mounted_tape):
+    p = mounted_tape / "xa_replace.txt"
+    p.write_text("payload")
+    with pytest.raises(OSError):
+        os.setxattr(p, _USER_NS + "test.r", b"x", flags=os.XATTR_REPLACE)
+
+
+def test_setxattr_create_on_existing_raises(mounted_tape):
+    p = mounted_tape / "xa_create.txt"
+    p.write_text("payload")
+    set_xattr(p, "test.c", "first")
+    with pytest.raises(FileExistsError):
+        os.setxattr(p, _USER_NS + "test.c", b"second", flags=os.XATTR_CREATE)
+
+
+def test_xattr_on_directory(mounted_tape):
+    d = mounted_tape / "xa_dir"
+    d.mkdir()
+    set_xattr(d, "test.tag", "v1")
+    assert get_xattr(d, "test.tag") == "v1"
+
+
+def test_xattr_survives_after_writes_to_file(mounted_tape):
+    p = mounted_tape / "xa_persist.txt"
+    p.write_text("v1")
+    set_xattr(p, "test.persist", "tag")
+    p.write_text("v2-longer-content")
+    assert get_xattr(p, "test.persist") == "tag"

--- a/tests/scenarios/run.sh
+++ b/tests/scenarios/run.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+: "${ALTFS_PREFIX:=/workspaces/altfs}"
+export PATH="${ALTFS_PREFIX}/bin:${PATH}"
+export LD_LIBRARY_PATH="${ALTFS_PREFIX}/lib:${LD_LIBRARY_PATH:-}"
+
+exec pytest "${SCRIPT_DIR}" "$@"

--- a/tests/scenarios/test_cp_recursive.py
+++ b/tests/scenarios/test_cp_recursive.py
@@ -1,0 +1,40 @@
+"""cp -r a populated tree from outside the FUSE mount into it, and
+verify diff -r shows no difference.
+
+Exercises the same code path users hit when archiving a project
+onto a tape: lots of small files, nested directories, copied via a
+real /usr/bin/cp invocation rather than the Python FS APIs.
+"""
+
+import os
+import shutil
+import subprocess
+
+
+def _populate_source(tmpdir):
+    """Build a moderately broad tree outside the tape mount."""
+    for d in ("docs", "src", "data"):
+        (tmpdir / d).mkdir()
+    (tmpdir / "docs" / "readme.txt").write_text("hello")
+    (tmpdir / "docs" / "notes.md").write_text("# notes\n* one\n* two\n")
+    (tmpdir / "src" / "main.c").write_text("int main(){return 0;}\n")
+    (tmpdir / "src" / "lib.h").write_text("#pragma once\n")
+    (tmpdir / "src" / "sub").mkdir()
+    (tmpdir / "src" / "sub" / "deep.c").write_text("// deep\n")
+    (tmpdir / "data" / "blob.bin").write_bytes(os.urandom(64 * 1024))
+
+
+def test_cp_recursive(mounted_tape, tmp_path):
+    src = tmp_path / "project"
+    src.mkdir()
+    _populate_source(src)
+
+    dst = mounted_tape / "project"
+    subprocess.run(["cp", "-r", str(src), str(dst)], check=True)
+
+    result = subprocess.run(
+        ["diff", "-r", str(src), str(dst)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/scenarios/test_deep_tree_mv.py
+++ b/tests/scenarios/test_deep_tree_mv.py
@@ -1,0 +1,58 @@
+"""Build a deep directory tree, mv it to a different deep location,
+verify every file and the tree shape survive intact.
+
+This exercises rename of a directory subtree (rather than a single
+dentry) and validates the descendants are reachable at the new
+path. The shallow rename case is already covered by test_rename.py;
+this scenario stresses the recursive descent.
+"""
+
+import os
+import shutil
+
+_DEPTH = 6
+_FILES_PER_DIR = 3
+
+
+def _build_tree(root):
+    cur = root
+    for level in range(_DEPTH):
+        cur = cur / f"d{level}"
+        cur.mkdir()
+        for i in range(_FILES_PER_DIR):
+            (cur / f"f{i}.txt").write_text(f"{level}:{i}")
+    return cur
+
+
+def _walk_contents(root):
+    return {
+        os.path.relpath(os.path.join(dp, fn), str(root)): open(
+            os.path.join(dp, fn)
+        ).read()
+        for dp, _, fns in os.walk(str(root))
+        for fn in fns
+    }
+
+
+def test_mv_deep_tree(mounted_tape):
+    src_root = mounted_tape / "src"
+    src_root.mkdir()
+    leaf = _build_tree(src_root)
+    (leaf / "leaf_marker.txt").write_text("the bottom")
+
+    before = _walk_contents(src_root)
+    assert len(before) == _DEPTH * _FILES_PER_DIR + 1
+
+    # mv src → a sibling deep destination chain
+    dst_parent = mounted_tape / "dst_chain"
+    dst_parent.mkdir()
+    for level in range(_DEPTH):
+        dst_parent = dst_parent / f"x{level}"
+        dst_parent.mkdir()
+    dst_root = dst_parent / "moved"
+
+    shutil.move(str(src_root), str(dst_root))
+
+    assert not src_root.exists()
+    after = _walk_contents(dst_root)
+    assert after == before

--- a/tests/scenarios/test_tar_extract.py
+++ b/tests/scenarios/test_tar_extract.py
@@ -1,0 +1,47 @@
+"""Pack a tarball on the host FS, extract it onto the FUSE mount,
+verify the file set and contents match.
+
+This is a write-heavy scenario that combines mkdir, file creation,
+and (when tar restores mtime/mode) utime/chmod against a real tar
+binary.
+"""
+
+import os
+import subprocess
+
+
+def _entries(root):
+    out = {}
+    for dp, _, fns in os.walk(str(root)):
+        for fn in fns:
+            full = os.path.join(dp, fn)
+            rel = os.path.relpath(full, str(root))
+            with open(full, "rb") as f:
+                out[rel] = f.read()
+    return out
+
+
+def test_tar_extract_onto_tape(mounted_tape, tmp_path):
+    src = tmp_path / "tar_src"
+    src.mkdir()
+    (src / "a.txt").write_text("alpha")
+    (src / "b").mkdir()
+    (src / "b" / "c.txt").write_text("charlie")
+    (src / "b" / "d.bin").write_bytes(os.urandom(8 * 1024))
+    (src / "b" / "deeper").mkdir()
+    (src / "b" / "deeper" / "e.txt").write_text("echo")
+
+    tarball = tmp_path / "src.tar"
+    subprocess.run(
+        ["tar", "-cf", str(tarball), "-C", str(src), "."],
+        check=True,
+    )
+
+    dst = mounted_tape / "extracted"
+    dst.mkdir()
+    subprocess.run(
+        ["tar", "-xf", str(tarball), "-C", str(dst)],
+        check=True,
+    )
+
+    assert _entries(src) == _entries(dst)

--- a/tests/scenarios/test_unicode_filenames.py
+++ b/tests/scenarios/test_unicode_filenames.py
@@ -1,0 +1,72 @@
+"""LTFS stores filenames as UTF-8 NFC on tape and compares them in
+case-fold + NFD form internally (pathname.c, ltfs_fuse.c). So:
+
+- An NFD path opens the same file as the equivalent NFC path.
+- A name passed in NFD ends up serialized as NFC in the index XML.
+- The three canonical forms of Å (U+212B, U+00C5, U+0041 U+030A) all
+  resolve to the same on-tape entry.
+
+All non-ASCII codepoints are written with explicit \\u escapes to
+guarantee the source bytes don't get silently re-normalized by an
+editor.
+"""
+
+import unicodedata
+
+from common.altfs import format_tape, mount_tape, umount_tape
+from common.index import parse_latest_index
+
+NFC_CAFE = "café.txt"        # é = U+00E9 (precomposed)
+NFD_CAFE = "café.txt"       # e + combining acute (decomposed)
+assert unicodedata.normalize("NFC", NFD_CAFE) == NFC_CAFE
+assert NFC_CAFE != NFD_CAFE
+
+
+def test_nfc_name_round_trips(mounted_tape):
+    p = mounted_tape / NFC_CAFE
+    p.write_text("nfc-payload")
+    assert p.read_text() == "nfc-payload"
+
+
+def test_nfd_lookup_finds_nfc_file(mounted_tape):
+    nfc = mounted_tape / "café-via-nfc.txt"
+    nfd = mounted_tape / "café-via-nfc.txt"
+    nfc.write_text("v1")
+    assert nfd.read_text() == "v1"
+
+
+def test_nfc_lookup_finds_nfd_file(mounted_tape):
+    nfd_create = mounted_tape / "café-via-nfd.txt"
+    nfc_lookup = mounted_tape / "café-via-nfd.txt"
+    nfd_create.write_text("v2")
+    assert nfc_lookup.read_text() == "v2"
+
+
+def test_angstrom_forms_resolve_to_same_file(mounted_tape):
+    # All three canonical forms of Å
+    angstrom_a = mounted_tape / "Ångstrom.txt"        # ANGSTROM SIGN
+    angstrom_b = mounted_tape / "Ångstrom.txt"        # LATIN CAPITAL A WITH RING ABOVE
+    angstrom_c = mounted_tape / "Ångstrom.txt"       # A + COMBINING RING ABOVE
+    angstrom_a.write_text("payload-from-atom")
+    assert angstrom_b.read_text() == "payload-from-atom"
+    assert angstrom_c.read_text() == "payload-from-atom"
+
+
+def test_nfd_name_is_stored_as_nfc_on_tape(tmp_path_factory):
+    base = tmp_path_factory.mktemp("altfs-nfc")
+    tape = base / "tape"
+    mnt = base / "mnt"
+    tape.mkdir()
+    mnt.mkdir()
+    format_tape(tape, serial="NFCTST", label="nfc")
+
+    mount_tape(tape, mnt)
+    try:
+        (mnt / NFD_CAFE).write_text("payload")
+    finally:
+        umount_tape(mnt)
+
+    root = parse_latest_index(tape)
+    names = [n.text for n in root.iter("name")]
+    assert NFC_CAFE in names
+    assert NFD_CAFE not in names


### PR DESCRIPTION
## What

Adds the foundation for scenario testing of Aurora LTFS:

- A pytest-based test pyramid under `tests/fsapi/` (FUSE filesystem API coverage) and `tests/scenarios/` (UNIX command scenarios).
- Shared helpers in `tests/common/` for the format/mount/umount lifecycle, xattr access, and direct on-tape index XML inspection with Python's stdlib XML parser (independent of altfs's libxml2 reader).
- A new `.github/workflows/scenario.yml` that runs both suites on Ubuntu 24.04 and a second job that rebuilds with `--coverage` and uploads to Codecov.
- A real altfs deadlock fix surfaced by the new tests: `ltfs_fsops_unlink` released `parent->meta_lock` at `out:` unconditionally while only acquiring it after the WORM / DIRNOTEMPTY checks. Bailing out (e.g. `rmdir` on a non-empty directory) left the rwlock corrupted and deadlocked the next op on the same parent.

Fixes #7

## How

- `tests/common/altfs.py` — `format_tape` / `mount_tape` / `umount_tape` helpers. `umount_tape` waits not only for the kernel mount to detach but also for the altfs daemon process to exit, so tests that inspect the tape directory after umount don't race the final index flush.
- `tests/common/helpers.py` — xattr accessors that prefix `user.` so callers can use the LTFS-side names (`ltfs.indexGeneration`, etc.).
- `tests/common/index.py` — finds the highest-numbered IP record whose payload starts with `<ltfsindex>` and parses it with `xml.etree`.
- `tests/conftest.py` — module-scoped `mounted_tape` fixture wraps the helpers so the bulk of fsapi tests share one mount per test file.
- `tests/fsapi/` — 11 files covering open/write/read at and across the 512 KiB block boundary, mkdir/rmdir/readdir, rename with an error-path audit using deadlock sentinels, stat/fstat, truncate/ftruncate, chmod and chown per the LTFS permission model, xattr (including base64-encoded unprintable values), symlink/readlink, utime, explicit `ltfs.vendor.Aurora.FullSync`, and a format → mount → write → umount → independent XML parse → re-mount → verify round-trip.
- `tests/scenarios/` — `deep_tree_mv`, `cp_recursive`, `tar_extract`, and `unicode_filenames` (NFC/NFD round-trip plus the three canonical forms of `Å` collapsing to U+00C5; the NFD-stored-as-NFC case checks the on-tape XML directly).
- `src/libltfs/ltfs_fsops.c` — `acquirewrite_mrsw(&parent->meta_lock)` hoisted above the WORM / DIRNOTEMPTY bail-outs so every path that reaches `out:` has it held.

## Why (optional)

Independent XML parsing matters because `altfsck`, `altfsindextool`, and the FUSE daemon all share the same libxml2-based reader. An "`altfsck` passes" check would not catch parser-level bugs that both sides would accept symmetrically; reading the captured index with `xml.etree` gives a truly independent verification of what hit the tape.

WORM-path testing for rename was intentionally deferred: the file backend can express a WORM cartridge but not with a single `mkaltfs` invocation, so those paths need fixtures that hand-build the directory state — work that fits better with a future scenario-level test expansion than this PR.

## Testing

### Test steps

    ./autogen.sh
    ./configure --prefix=$ALTFS_PREFIX
    make -j"$(nproc)"
    make install
    sudo apt-get install -y python3-pytest
    ALTFS_PREFIX=$ALTFS_PREFIX bash tests/fsapi/run.sh -v
    ALTFS_PREFIX=$ALTFS_PREFIX bash tests/scenarios/run.sh -v

### Test environment

- Tested on: Ubuntu 24.04 (devcontainer + GitHub Actions runner)
- Added automated tests: 71 in `tests/fsapi/` + 8 in `tests/scenarios/` = 79 new tests, all running on every PR via the new `scenario.yml` workflow plus a second coverage job that uploads to Codecov.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## AI Usage

- [x] AI tools were used (please describe below)

**AI tool(s) used:** Claude Code (Opus 4.7 / 1M context)

**Scope of AI assistance:**
- Test design and implementation: fixture/helper layout, per-API test files, incremental commits.
- Deadlock diagnosis on `ltfs_fsops_unlink`: kernel/process state inspection, identifying the lock-order bug and authoring the fix (reviewed by the contributor before commit).
- CI workflow (`scenario.yml`) and Codecov wiring.
- Commit messages and this PR description.

All AI-generated content was reviewed by the contributor before commit. Scope decisions (test ordering, WORM-path deferral, choosing `xml.etree` over `altfsck` for integrity verification) were made in conversation with the contributor, not by the AI alone.