### PR TITLE
test: cover CLI option paths and percent-encoded names

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,44 @@
+# Codecov configuration for Aurora LTFS.
+# Reference: https://docs.codecov.com/docs/codecov-yaml
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+    patch:
+      default:
+        target: auto
+        threshold: 5%
+
+# Paths excluded from the coverage denominator.
+#
+# The integration test harness only exercises libltfs through the
+# `file` debug backend on a Linux runner. Sources that require
+# other operating systems or real SCSI hardware are unreachable
+# from CI and would distort the percentage if counted.
+ignore:
+  # Other-OS tape backends.
+  - "src/tape_drivers/osx/**/*"
+  - "src/tape_drivers/freebsd/**/*"
+  - "src/tape_drivers/netbsd/**/*"
+
+  # Linux SCSI generic driver — needs a real tape drive.
+  - "src/tape_drivers/linux/sg/**/*"
+
+  # Real-drive vendor support files at the top level. The file
+  # backend at src/tape_drivers/generic/file/ does not link
+  # against these; they only ship with the SCSI/IOKit/CAM paths
+  # above.
+  - "src/tape_drivers/crc32c_crc.c"
+  - "src/tape_drivers/reed_solomon_crc.c"
+  - "src/tape_drivers/hp_tape.c"
+  - "src/tape_drivers/ibm_tape.c"
+  - "src/tape_drivers/quantum_tape.c"
+  - "src/tape_drivers/vendor_compat.c"
+  - "src/tape_drivers/open_factor.c"
+
+  # AGENTS.md flags fcfs as a sample I/O scheduler that is "not
+  # used at all" — the unified scheduler is mandatory.
+  - "src/iosched/fcfs.c"

--- a/tests/fsapi/test_percent_encoding.py
+++ b/tests/fsapi/test_percent_encoding.py
@@ -1,0 +1,98 @@
+"""Round-trip for file and directory names that require percent
+encoding in the on-tape XML index.
+
+LTFS reserves a small set of code points that must not appear
+literally in <name> elements: the ASCII colon (`:`, 0x3A) and the
+C0 control characters except TAB/LF/CR. When a name contains any
+of them, libltfs writes the name with `percentencoded="true"` and
+escapes the disallowed bytes as `%XX`. The reader does the inverse.
+
+Without this test the encoder and decoder are exercised only when
+some other test happens to use a control character — currently
+none do, so both code paths were entirely unwalked by CI.
+
+Pattern follows test_index_roundtrip.py: format → mount → write →
+umount → inspect the IP record with the stdlib XML parser → re-mount
+→ verify names come back identical and content is intact.
+"""
+
+import xml.etree.ElementTree as ET
+
+from common.altfs import format_tape, mount_tape, umount_tape
+from common.index import find_latest_index_record
+
+
+FILE_NAME = "log:2026-06-16.txt"        # `:` triggers percent encoding
+DIR_NAME = "session:01"                 # same trigger on a directory
+INNER_NAME = "plain.txt"                # nested non-encoded name
+FILE_BODY = "payload-with-colon"
+INNER_BODY = "inside the percent-encoded directory"
+
+
+def _walk_named_entries(root):
+    """Yield (tag, name_element) for every <file>/<directory> in the index."""
+    for elem in root.iter():
+        if elem.tag in ("file", "directory"):
+            name_el = elem.find("name")
+            if name_el is not None:
+                yield elem.tag, name_el
+
+
+def test_percent_encoded_names_round_trip(tmp_path_factory):
+    base = tmp_path_factory.mktemp("altfs-percent")
+    tape_dir = base / "tape"
+    mnt = base / "mnt"
+    tape_dir.mkdir()
+    mnt.mkdir()
+
+    format_tape(tape_dir, serial="PCTENC", label="percent")
+
+    mount_tape(tape_dir, mnt)
+    try:
+        (mnt / FILE_NAME).write_text(FILE_BODY)
+        (mnt / DIR_NAME).mkdir()
+        (mnt / DIR_NAME / INNER_NAME).write_text(INNER_BODY)
+    finally:
+        umount_tape(mnt)
+
+    # Inspect the raw XML: the writer should have emitted the colon
+    # as %3A and tagged the element percentencoded="true".
+    index_path = find_latest_index_record(tape_dir)
+    tree = ET.parse(index_path)
+    root = tree.getroot()
+
+    by_encoded_name = {}
+    for tag, name_el in _walk_named_entries(root):
+        by_encoded_name[name_el.text] = (tag, name_el)
+
+    encoded_file = FILE_NAME.replace(":", "%3A")
+    encoded_dir = DIR_NAME.replace(":", "%3A")
+
+    assert encoded_file in by_encoded_name, sorted(by_encoded_name)
+    assert encoded_dir in by_encoded_name, sorted(by_encoded_name)
+
+    file_tag, file_name_el = by_encoded_name[encoded_file]
+    dir_tag, dir_name_el = by_encoded_name[encoded_dir]
+    assert file_tag == "file"
+    assert dir_tag == "directory"
+    assert file_name_el.attrib.get("percentencoded") == "true"
+    assert dir_name_el.attrib.get("percentencoded") == "true"
+
+    # A plain-ASCII sibling should NOT be flagged — verifies the
+    # writer only sets the attribute when actually needed.
+    assert INNER_NAME in by_encoded_name
+    _, inner_name_el = by_encoded_name[INNER_NAME]
+    assert inner_name_el.attrib.get("percentencoded") in (None, "false")
+
+    # Re-mount: the reader must decode %3A back to ':' so the name
+    # is visible through FUSE under its original spelling.
+    mount_tape(tape_dir, mnt)
+    try:
+        assert (mnt / FILE_NAME).read_text() == FILE_BODY
+        assert (mnt / DIR_NAME / INNER_NAME).read_text() == INNER_BODY
+
+        listing = {p.name for p in mnt.iterdir()}
+        assert FILE_NAME in listing
+        assert DIR_NAME in listing
+    finally:
+        umount_tape(mnt)

--- a/tests/scenarios/test_altfsck.py
+++ b/tests/scenarios/test_altfsck.py
@@ -1,0 +1,102 @@
+"""Integration coverage for altfsck against file-backend tapes.
+
+altfsck has multiple modes (default check, list rollback points,
+capture index, rollback, verify-against-generation) and outside of
+the legacy bash recovery scenario none of them ran inside the
+pytest harness, so coverage of `src/cmd/altfsck/altfsck.c` was
+near zero on Codecov.
+
+These tests exercise the modes that do not require encryption or
+real rollback. The multi-generation case uses `ltfs.sync` with a
+commit message to advance the generation deterministically: each
+setxattr forces a full index write tagged with the message, which
+then surfaces in `altfsck -l` output. This avoids depending on
+the file backend's timing emulation and produces a stable tape
+state we can assert against.
+"""
+
+import subprocess
+
+from common.altfs import format_tape, mount_tape, umount_tape
+from common.helpers import set_xattr
+
+
+_RUN_TIMEOUT = 30
+
+
+def _altfsck(*extra_args, tape_dir):
+    return subprocess.run(
+        ["altfsck", "-e", "file", *extra_args, str(tape_dir)],
+        capture_output=True,
+        text=True,
+        timeout=_RUN_TIMEOUT,
+    )
+
+
+def test_altfsck_modes_on_clean_tape(tmp_path_factory):
+    """A freshly formatted tape exposes one rollback point (the
+    initial format) and is consistent under default check; the
+    --capture-index mode must emit the format-generation schema
+    files into the output directory."""
+    base = tmp_path_factory.mktemp("altfsck-clean")
+    tape_dir = base / "tape"
+    tape_dir.mkdir()
+    format_tape(tape_dir, serial="FSCKCL", label="fsck-clean")
+
+    # Default check: altfsck returns LTFSCK_NO_ERRORS (0) or
+    # LTFSCK_CORRECTED (1) on a consistent volume — both indicate
+    # the volume was processed cleanly without unrecoverable error.
+    check = _altfsck(tape_dir=tape_dir)
+    assert check.returncode in (0, 1), check.stderr
+    assert "consistent" in (check.stdout + check.stderr).lower()
+
+    # -l: rollback-point listing should mention the initial index.
+    listing = _altfsck("-l", tape_dir=tape_dir)
+    assert listing.returncode == 0, listing.stderr
+    listing_out = listing.stdout + listing.stderr
+    assert "Initial Index" in listing_out
+    assert "Format -" in listing_out  # auto-generated format comment
+
+    # --capture-index: writes one <barcode>-<gen>-<id>.schema file
+    # per partition copy of each index. A clean tape has the
+    # initial index on the DP, so at least one schema file lands
+    # in the output directory.
+    capture_dir = base / "capture"
+    capture_dir.mkdir()
+    cap = _altfsck(f"--capture-index={capture_dir}", tape_dir=tape_dir)
+    assert cap.returncode == 0, cap.stderr
+    schemas = list(capture_dir.glob("*.schema"))
+    assert schemas, f"no schema files produced: {list(capture_dir.iterdir())}"
+    # Captured XML should start with the LTFS index root element.
+    head = schemas[0].read_bytes()[:128]
+    assert b"<ltfsindex" in head
+
+
+def test_altfsck_l_lists_commit_messages_from_synced_writes(tmp_path_factory):
+    """Each `setxattr user.ltfs.sync = <msg>` on the mount root
+    forces a full index write tagged with the message. After three
+    such cycles the rollback-point listing must contain every
+    commit message we recorded, plus the initial-format entry."""
+    base = tmp_path_factory.mktemp("altfsck-multi")
+    tape_dir = base / "tape"
+    mnt = base / "mnt"
+    tape_dir.mkdir()
+    mnt.mkdir()
+
+    format_tape(tape_dir, serial="FSCKMG", label="fsck-multi")
+    mount_tape(tape_dir, mnt)
+    try:
+        commits = ["alpha commit", "bravo commit", "charlie commit"]
+        for i, msg in enumerate(commits, start=1):
+            (mnt / f"f{i}.txt").write_text(f"file {i}")
+            set_xattr(mnt, "ltfs.sync", msg)
+    finally:
+        umount_tape(mnt)
+
+    listing = _altfsck("-l", tape_dir=tape_dir)
+    assert listing.returncode == 0, listing.stderr
+    out = listing.stdout + listing.stderr
+
+    for msg in commits:
+        assert msg in out, f"missing commit message {msg!r} in:\n{out}"
+    assert "Initial Index" in out

--- a/tests/scenarios/test_cli_options.py
+++ b/tests/scenarios/test_cli_options.py
@@ -99,3 +99,60 @@ def test_mkaltfs_open_failure_on_bogus_device():
     )
     assert r.returncode != 0
     assert "open" in (r.stdout + r.stderr).lower()
+
+
+# ---------- altfsck ----------
+
+
+def test_altfsck_version_exits_zero():
+    r = _run("altfsck", "--version")
+    assert r.returncode == 0, r.stderr
+    assert "version" in (r.stdout + r.stderr).lower()
+
+
+def test_altfsck_help_exits_zero():
+    r = _run("altfsck", "--help")
+    assert r.returncode == 0, r.stderr
+    assert "usage" in (r.stdout + r.stderr).lower()
+
+
+def test_altfsck_no_args_fails():
+    r = _run("altfsck")
+    assert r.returncode != 0
+
+
+def test_altfsck_verify_without_generation_rejected(tmp_path):
+    # MODE_VERIFY (-n / --no-rollback) requires --generation; the
+    # validator should reject before opening the device.
+    r = _run("altfsck", "-e", "file", "-n", str(tmp_path))
+    assert r.returncode != 0
+
+
+# ---------- altfsindextool ----------
+
+
+def test_altfsindextool_version_exits_zero():
+    r = _run("altfsindextool", "--version")
+    assert r.returncode == 0, r.stderr
+    assert "version" in (r.stdout + r.stderr).lower()
+
+
+def test_altfsindextool_help_exits_zero():
+    r = _run("altfsindextool", "--help")
+    assert r.returncode == 0, r.stderr
+    assert "usage" in (r.stdout + r.stderr).lower()
+
+
+def test_altfsindextool_no_args_fails():
+    r = _run("altfsindextool")
+    assert r.returncode != 0
+
+
+def test_altfsindextool_open_failure_on_bogus_device(tmp_path):
+    r = _run(
+        "altfsindextool", "-e", "file",
+        "-d", "/nonexistent/path",
+        f"--output-dir={tmp_path}",
+    )
+    assert r.returncode != 0
+    assert "open" in (r.stdout + r.stderr).lower()

--- a/tests/scenarios/test_cli_options.py
+++ b/tests/scenarios/test_cli_options.py
@@ -1,0 +1,101 @@
+"""CLI option-parser and early-exit paths for altfs and mkaltfs.
+
+These tests do not mount a tape. They invoke each binary with
+options that terminate before (or instead of) the FUSE main loop:
+version banners, help screens, the device-list mode, and a few
+expected error paths (missing required option, unopenable device).
+
+The coverage target is the startup sequence each command shares —
+locale resolution, ltfs_init, message-plugin load, getopt parsing,
+usage printers, and (for device_list) the tape plugin dispatch.
+Every invocation has a short timeout so a regression that hangs a
+command fails the test cleanly instead of stalling CI.
+"""
+
+import subprocess
+
+
+_TIMEOUT = 10
+
+
+def _run(*args):
+    return subprocess.run(
+        list(args),
+        capture_output=True,
+        text=True,
+        timeout=_TIMEOUT,
+    )
+
+
+# ---------- altfs ----------
+
+
+def test_altfs_version_exits_zero():
+    r = _run("altfs", "--version")
+    assert r.returncode == 0, r.stderr
+    assert "version" in (r.stdout + r.stderr).lower()
+
+
+def test_altfs_help_exits_zero():
+    r = _run("altfs", "-h")
+    assert r.returncode == 0, r.stderr
+    assert "usage" in (r.stdout + r.stderr).lower()
+
+
+def test_altfs_no_args_reports_missing_device():
+    r = _run("altfs")
+    assert r.returncode != 0
+    # The default Linux backend (sg) has no default device. Exact
+    # message text may evolve; both spellings of the noun appear in
+    # the diagnostic and either is a reasonable signal.
+    combined = (r.stdout + r.stderr).lower()
+    assert "devname" in combined or "device" in combined
+
+
+def test_altfs_device_list_with_file_backend(tmp_path):
+    r = _run(
+        "altfs",
+        "-o", "tape_backend=file",
+        "-o", f"devname={tmp_path}",
+        "-o", "device_list",
+    )
+    assert r.returncode == 0, r.stderr
+    assert "Tape Device list" in (r.stdout + r.stderr)
+
+
+# ---------- mkaltfs ----------
+
+
+def test_mkaltfs_version_exits_zero():
+    r = _run("mkaltfs", "--version")
+    assert r.returncode == 0, r.stderr
+    assert "version" in (r.stdout + r.stderr).lower()
+
+
+def test_mkaltfs_help_exits_zero():
+    r = _run("mkaltfs", "--help")
+    assert r.returncode == 0, r.stderr
+    assert "usage" in (r.stdout + r.stderr).lower()
+
+
+def test_mkaltfs_no_args_fails():
+    r = _run("mkaltfs")
+    assert r.returncode != 0
+
+
+def test_mkaltfs_short_serial_rejected(tmp_path):
+    # Serial must be exactly 6 characters (see tests/common/altfs.py
+    # and the AGENTS conventions). 5-character serials should fail
+    # option validation before any device I/O is attempted.
+    r = _run("mkaltfs", "-e", "file", "-d", str(tmp_path), "-s", "SHORT")
+    assert r.returncode != 0
+
+
+def test_mkaltfs_open_failure_on_bogus_device():
+    r = _run(
+        "mkaltfs", "-e", "file",
+        "-d", "/nonexistent/path",
+        "-s", "123456",
+    )
+    assert r.returncode != 0
+    assert "open" in (r.stdout + r.stderr).lower()

--- a/tests/scenarios/test_mkaltfs_rules.py
+++ b/tests/scenarios/test_mkaltfs_rules.py
@@ -16,9 +16,10 @@ landed on.
 
 import os
 import subprocess
+import xml.etree.ElementTree as ET
 
 from common.altfs import mount_tape, umount_tape
-from common.helpers import list_records
+from common.helpers import list_records, set_xattr
 
 
 def _format_with_rules(tape_dir, rules, *, serial, label="rules"):
@@ -36,10 +37,43 @@ def _concat_bytes(record_paths):
     return b"".join(p.read_bytes() for p in record_paths)
 
 
+def _parse_index_records(record_paths):
+    """Return [(generation, root_element), ...] sorted ascending for every
+    record file under the given paths that holds an <ltfsindex>."""
+    out = []
+    for p in record_paths:
+        if b"<ltfsindex" not in p.read_bytes()[:128]:
+            continue
+        root = ET.parse(p).getroot()
+        gen_el = root.find("generationnumber")
+        if gen_el is None:
+            continue
+        out.append((int(gen_el.text), root))
+    out.sort(key=lambda kv: kv[0])
+    return out
+
+
+def _file_extent_partition(root, filename):
+    """Letter ('a' or 'b') of the first extent's partition for the named file
+    inside an <ltfsindex> root, or None if the file is absent."""
+    for f in root.iter("file"):
+        name = f.find("name")
+        if name is not None and name.text == filename:
+            partition = f.find(".//extent/partition")
+            return partition.text if partition is not None else None
+    return None
+
+
 def test_mkaltfs_rules_size_and_name_route_only_matches_to_ip(tmp_path_factory):
     """`size=1M/name=*.jpg` caches a matching, under-cap file on
     the IP. A name mismatch or a name match that overshoots the
-    size cap stays on the DP only."""
+    size cap stays on the DP only.
+
+    A mid-test `ltfs.sync` after writing the cached file leaves a
+    DP-only index (gen 2) that predates the later writes, so we
+    can verify that the older DP index references DP storage for
+    photo.jpg while the latest IP index reroutes the same file
+    to its cached IP copy."""
     base = tmp_path_factory.mktemp("rules-mix")
     tape_dir = base / "tape"
     mnt = base / "mnt"
@@ -55,6 +89,10 @@ def test_mkaltfs_rules_size_and_name_route_only_matches_to_ip(tmp_path_factory):
     mount_tape(tape_dir, mnt)
     try:
         (mnt / "photo.jpg").write_bytes(small_match + b"x" * 200)
+        # Forces a DP-only index write tagged with this commit
+        # message. This generation has only photo.jpg and is the
+        # "previous DP index" referenced in the assertions below.
+        set_xattr(mnt, "ltfs.sync", "after-photo")
         # 2 MiB exceeds the 1 MiB cache cap; matches the name glob
         # but must not be cached on the IP.
         big_payload = big_match + os.urandom(2 * 1024 * 1024 - len(big_match))
@@ -67,12 +105,40 @@ def test_mkaltfs_rules_size_and_name_route_only_matches_to_ip(tmp_path_factory):
     ip_bytes = _concat_bytes(ip_records)
     dp_bytes = _concat_bytes(dp_records)
 
+    # Raw-byte placement.
     assert small_match in ip_bytes, "matching small file should be cached on IP"
     assert small_match in dp_bytes, "matching small file must also exist on DP"
     assert big_match not in ip_bytes, "oversize match must not reach IP"
     assert big_match in dp_bytes
     assert nonmatch not in ip_bytes, "name mismatch must not reach IP"
     assert nonmatch in dp_bytes
+
+    # Index XML cross-check.
+    ip_indexes = _parse_index_records(ip_records)
+    dp_indexes = _parse_index_records(dp_records)
+
+    # Latest IP index reroutes the cached file to partition 'a'
+    # (the IP), and leaves the non-cached files pointing into the
+    # DP. This is what makes the cached copy actually useful — the
+    # rapid-access lookup hits IP without traversing the DP.
+    latest_ip_gen, latest_ip_root = ip_indexes[-1]
+    assert _file_extent_partition(latest_ip_root, "photo.jpg") == "a"
+    assert _file_extent_partition(latest_ip_root, "notes.txt") == "b"
+    assert _file_extent_partition(latest_ip_root, "big.jpg") == "b"
+
+    # The DP index from before the mid-test sync (gen 2 in this
+    # scenario — gen 1 is the empty format-time index) saw only
+    # photo.jpg and pointed at its DP copy. That older DP view
+    # must remain DP-anchored: the IP cache is a forward
+    # optimization, not a retroactive rewrite of past generations.
+    prior_dp_gens = [g for g, _ in dp_indexes if g < latest_ip_gen]
+    assert prior_dp_gens, f"expected an older DP index before gen {latest_ip_gen}"
+    prev_dp_gen, prev_dp_root = next(
+        (g, r) for g, r in dp_indexes
+        if _file_extent_partition(r, "photo.jpg") is not None
+        and g < latest_ip_gen
+    )
+    assert _file_extent_partition(prev_dp_root, "photo.jpg") == "b"
 
 
 def test_mkaltfs_rules_size_only_caches_any_small_file_on_ip(tmp_path_factory):

--- a/tests/scenarios/test_mkaltfs_rules.py
+++ b/tests/scenarios/test_mkaltfs_rules.py
@@ -1,0 +1,165 @@
+"""Coverage for mkaltfs --rules and the index_criteria.c match path.
+
+Without --rules every test in the harness leaves the index in its
+"no criteria" state, so the parse, glob-cache, and caseless match
+code in src/libltfs/index_criteria.c is never exercised. These
+tests format a fresh tape with a rule, write files that hit each
+leg of it, and check on-tape placement on the file backend.
+
+LTFS caches data that matches the rule on the index partition (IP,
+partition 0) while always writing the full bytes to the data
+partition (DP, partition 1). The file backend lays each tape block
+down as a separate <part>_<block>_R record file, so we can read
+the raw record contents and assert which partition each marker
+landed on.
+"""
+
+import os
+import subprocess
+
+from common.altfs import mount_tape, umount_tape
+from common.helpers import list_records
+
+
+def _format_with_rules(tape_dir, rules, *, serial, label="rules"):
+    """Format a fresh file-backend tape with the given --rules string."""
+    subprocess.run(
+        ["mkaltfs", "-e", "file", "-d", str(tape_dir),
+         "-s", serial, "-n", label,
+         f"--rules={rules}", "-f"],
+        check=True,
+        capture_output=True,
+    )
+
+
+def _concat_bytes(record_paths):
+    return b"".join(p.read_bytes() for p in record_paths)
+
+
+def test_mkaltfs_rules_size_and_name_route_only_matches_to_ip(tmp_path_factory):
+    """`size=1M/name=*.jpg` caches a matching, under-cap file on
+    the IP. A name mismatch or a name match that overshoots the
+    size cap stays on the DP only."""
+    base = tmp_path_factory.mktemp("rules-mix")
+    tape_dir = base / "tape"
+    mnt = base / "mnt"
+    tape_dir.mkdir()
+    mnt.mkdir()
+
+    _format_with_rules(tape_dir, "size=1M/name=*.jpg", serial="RULEMX")
+
+    small_match = b"MATCH-SMALL-JPG-MARKER"
+    big_match = b"MATCH-BIG-JPG-MARKER"
+    nonmatch = b"NAME-MISMATCH-TXT-MARKER"
+
+    mount_tape(tape_dir, mnt)
+    try:
+        (mnt / "photo.jpg").write_bytes(small_match + b"x" * 200)
+        # 2 MiB exceeds the 1 MiB cache cap; matches the name glob
+        # but must not be cached on the IP.
+        big_payload = big_match + os.urandom(2 * 1024 * 1024 - len(big_match))
+        (mnt / "big.jpg").write_bytes(big_payload)
+        (mnt / "notes.txt").write_bytes(nonmatch + b"y" * 200)
+    finally:
+        umount_tape(mnt)
+
+    ip_records, dp_records = list_records(tape_dir)
+    ip_bytes = _concat_bytes(ip_records)
+    dp_bytes = _concat_bytes(dp_records)
+
+    assert small_match in ip_bytes, "matching small file should be cached on IP"
+    assert small_match in dp_bytes, "matching small file must also exist on DP"
+    assert big_match not in ip_bytes, "oversize match must not reach IP"
+    assert big_match in dp_bytes
+    assert nonmatch not in ip_bytes, "name mismatch must not reach IP"
+    assert nonmatch in dp_bytes
+
+
+def test_mkaltfs_rules_size_only_caches_any_small_file_on_ip(tmp_path_factory):
+    """A `size=…` rule with no `name=…` leg lets every under-cap
+    file land on the IP — this is the index_criteria_match
+    early-return when glob_patterns is NULL."""
+    base = tmp_path_factory.mktemp("rules-size-only")
+    tape_dir = base / "tape"
+    mnt = base / "mnt"
+    tape_dir.mkdir()
+    mnt.mkdir()
+
+    _format_with_rules(tape_dir, "size=100K", serial="RULESS")
+
+    a_marker = b"ANY-NAME-DAT-MARKER"
+    b_marker = b"OTHER-NAME-XYZ-MARKER"
+
+    mount_tape(tape_dir, mnt)
+    try:
+        (mnt / "any-name.dat").write_bytes(a_marker + b"a" * 200)
+        (mnt / "other.xyz").write_bytes(b_marker + b"b" * 200)
+    finally:
+        umount_tape(mnt)
+
+    ip_records, _ = list_records(tape_dir)
+    ip_bytes = _concat_bytes(ip_records)
+
+    assert a_marker in ip_bytes
+    assert b_marker in ip_bytes
+
+
+def test_mkaltfs_rules_multiple_name_globs(tmp_path_factory):
+    """`name=*.jpg:*.png` accepts files matching either extension.
+    A file matching neither stays on the DP only."""
+    base = tmp_path_factory.mktemp("rules-multi-glob")
+    tape_dir = base / "tape"
+    mnt = base / "mnt"
+    tape_dir.mkdir()
+    mnt.mkdir()
+
+    _format_with_rules(tape_dir, "size=1M/name=*.jpg:*.png", serial="RULEMG")
+
+    jpg = b"JPG-EXT-MARKER"
+    png = b"PNG-EXT-MARKER"
+    txt = b"TXT-EXT-MARKER"
+
+    mount_tape(tape_dir, mnt)
+    try:
+        (mnt / "a.jpg").write_bytes(jpg + b"a" * 100)
+        (mnt / "b.png").write_bytes(png + b"b" * 100)
+        (mnt / "c.txt").write_bytes(txt + b"c" * 100)
+    finally:
+        umount_tape(mnt)
+
+    ip_records, dp_records = list_records(tape_dir)
+    ip_bytes = _concat_bytes(ip_records)
+    dp_bytes = _concat_bytes(dp_records)
+
+    assert jpg in ip_bytes
+    assert png in ip_bytes
+    assert txt not in ip_bytes
+    assert txt in dp_bytes
+
+
+def test_mkaltfs_rules_invalid_syntax_rejected(tmp_path):
+    """A malformed --rules string must be rejected before any
+    bytes touch the tape. Exact exit code is not part of the
+    contract — only that it is non-zero and no record files were
+    written."""
+    r = subprocess.run(
+        ["mkaltfs", "-e", "file", "-d", str(tmp_path),
+         "-s", "BADRUL", "-n", "bad",
+         "--rules=this=is=garbage", "-f"],
+        capture_output=True, text=True, timeout=10,
+    )
+    assert r.returncode != 0
+    ip_records, dp_records = list_records(tmp_path)
+    assert ip_records == [] and dp_records == []
+
+
+def test_mkaltfs_rules_invalid_size_value_rejected(tmp_path):
+    """`size=oops` exercises the dedicated parse_size error path
+    distinct from the unknown-keyword path covered above."""
+    r = subprocess.run(
+        ["mkaltfs", "-e", "file", "-d", str(tmp_path),
+         "-s", "BADSIZ", "-n", "bad",
+         "--rules=size=oops", "-f"],
+        capture_output=True, text=True, timeout=10,
+    )
+    assert r.returncode != 0


### PR DESCRIPTION
## What

Extends the pytest integration harness toward Issue #35, covering:

- altfs / mkaltfs / altfsck / altfsindextool option-parser and early-exit paths.
- File and directory name percent-encoding round-trip through the on-tape XML.
- altfsck default check, rollback-point listing, and the `--capture-index` mode, with a multi-generation tape state built deterministically via `ltfs.sync` commit messages.
- The `mkaltfs --rules` data-placement policy in `src/libltfs/index_criteria.c`, with raw record placement and index XML cross-checks.
- A `codecov.yml` to keep the reported coverage % fair as previously-uninstrumented LOC enters the report.

Toward #35. (`tests/incindex-recovery/` activation and the `altfsindextool` capture-success test — the latter blocked by #38 — are intentionally left for follow-up PRs.)

## How

Five new test files and one Codecov configuration.

- `tests/scenarios/test_cli_options.py` (17 cases) — `--version`, `--help`, no-args, plus one focused error per command: `altfs -o device_list` with the file backend (walks the tape-plugin dispatch), `mkaltfs -s SHORT`, `mkaltfs -d /nonexistent`, `altfsck -n` without `-g` (validate_options rejects MODE_VERIFY), `altfsindextool -d /nonexistent`. Each invocation runs under a 10 s subprocess timeout so a regression that hangs a command fails the test instead of stalling CI.

- `tests/fsapi/test_percent_encoding.py` — file and directory names containing `:` round-trip through the on-tape XML. The writer emits `percentencoded="true"` with `%3A`, a plain-ASCII sibling is not flagged, and the reader decodes the name back so the file is visible via FUSE on re-mount. `fs_is_percent_encode_required` triggers on `:` (0x3A) and C0 controls except TAB/LF/CR; both legs are now walked.

- `tests/scenarios/test_altfsck.py` (2 cases) — default check (accepts `LTFSCK_NO_ERRORS`=0 or `LTFSCK_CORRECTED`=1 as success), `-l` listing, `--capture-index=<dir>` (asserts `*.schema` files exist and start with `<ltfsindex`), and a multi-generation tape produced via `setxattr user.ltfs.sync = "<commit>"` per write. Each setxattr forces a tagged full-index write, then `altfsck -l` lists every commit message.

- `tests/scenarios/test_mkaltfs_rules.py` (5 cases) — format with a rule, write marked files, and inspect raw record bytes per partition plus index XML:
  - `size=1M/name=*.jpg`: matching under-cap → cached on IP, matching over-cap → DP only, name mismatch → DP only. The latest IP index reroutes the cached file to partition `a`; an older DP index left by a mid-test `ltfs.sync` still references partition `b` for the same file (the IP cache is forward-only, not a retroactive rewrite of past DP-only views).
  - `size=100K` (size only): every under-cap file reaches IP — the `glob_patterns == NULL` short-circuit in `index_criteria_match`.
  - `size=1M/name=*.jpg:*.png`: both extensions reach IP, a third extension does not.
  - Two invalid `--rules` strings (unknown keyword and bad size value): mkaltfs exits non-zero and writes no record files.

- `codecov.yml` — `target: auto, threshold: 5%` for both `project` and `patch` status (small denominator shifts during test expansion should not fail Codecov), plus an ignore list for paths the Ubuntu CI runner cannot reach: other-OS backends (`osx/`, `freebsd/`, `netbsd/`), `linux/sg/`, real-drive vendor support at the top of `src/tape_drivers/` (ibm/hp/quantum_tape.c, vendor_compat.c, crc32c_crc.c, reed_solomon_crc.c, open_factor.c), and the sample `iosched/fcfs.c`. The `generic/file/` backend stays in the denominator.

## Why

Issue #35 asked for the integration harness to reach beyond the FUSE happy path. The four commands and the `--rules` match path in `index_criteria.c` were previously unwalked by CI, and the percent-encoding round-trip had no verification at all.

The `codecov.yml` came out of a real symptom that surfaced mid-PR: after the first two test commits the reported coverage % went **down**, because previously-zero-coverage binaries (altfsck.c at 1554 LOC, altfsindextool.c at 779 LOC) entered the lcov report at low coverage and grew the denominator faster than the numerator. The ignore list + threshold restore a fair signal.

KMI / encryption coverage was deliberately deferred. The `altfsindextool` capture path is also deferred — `KEY_MAX_OFFSET=0x30` is one byte short of containing `<ltfsindex` after the standard XML declaration, so the scan rejects every block on the file backend (#38).

## Testing

### Test steps

```bash
./autogen.sh
./configure --prefix=/workspaces/altfs
make -j"$(nproc)"
make install
bash tests/fsapi/run.sh -v
bash tests/scenarios/run.sh -v
```

Local pytest counts on this branch:

| Suite     | Before | After |
|-----------|-------:|------:|
| fsapi     |     71 |    72 |
| scenarios |      8 |    32 |

All previously-passing tests still pass; no production code was changed.

### Test environment

- Tested on: Ubuntu 24.04 (devcontainer), x86_64, file tape backend.
- Added automated tests: see file list under "How" — 25 new pytest cases across one fsapi file and three scenarios files.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## AI Usage

- [ ] No AI tools were used in this contribution
- [x] AI tools were used (please describe below)

**AI tool(s) used:** Claude Code (Opus 4.7).

**Scope of AI assistance:** Code generation for the test files and the codecov.yml, exploratory probes against the local build to verify exact CLI exit codes and on-tape XML layout, and drafting this PR description. Test scope, fixture design (`ltfs.sync` for deterministic multi-generation tapes; index XML cross-check across generations), and the codecov.yml ignore list were authored interactively with the maintainer.
