### PR TITLE
Add encryption support for HP LTO drives (Linux, LTO-6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Tier 2 and Tier 3 platforms may be promoted or added based on community demand a
   | IBM     | TS1155                  | None              |
   | IBM     | TS1160                  | None              |
   | HP      | LTO5                    | T.B.D.            |
-  | HP      | LTO6                    | T.B.D.            |
+  | HP      | LTO6                    | 25MW (6250 FC)    |
   | HP      | LTO7                    | T.B.D.            |
   | HP      | LTO8                    | T.B.D.            |
   | HP      | LTO9                    | T.B.D.            |

--- a/messages/libaltfs/lb_root.txt
+++ b/messages/libaltfs/lb_root.txt
@@ -320,5 +320,6 @@ root:table {
 		ALB0280E:string { "UUID in the index does not match the label" }
 		ALB0281I:string { "Wrote inc-index of %s (Gen = %lld, Part = %c, Pos = %lld, %s)" }
 		ALB0282I:string { "Info inc-index, Gen = %lld, Full Part = %c, Full Pos = %lld, Back Part = %c, Back Pos = %lld)" }
+		ALB0283W:string { "VCR buffer flush (WFM 0) failed with %d; VCI may be stale. Next mount will retry" }
 	}
 }

--- a/src/libltfs/ltfs.c
+++ b/src/libltfs/ltfs.c
@@ -2695,6 +2695,15 @@ int ltfs_write_index(char partition, char *reason, enum ltfs_index_type type, st
 		goto out_write_perm;
 	}
 
+	/* Flush drive write buffer before reading VCR for VCI update. Without this, the drive
+	 * may not have committed all pending writes to tape medium when VCI is written to MAM,
+	 * leaving VCR ahead of VCI and triggering a spurious full consistency check on next mount. */
+	if (type == LTFS_FULL_INDEX && vol->device->needs_wfm_flush) {
+		int flush_ret = tape_write_filemark(vol->device, 0, true, true, false);
+		if (flush_ret < 0)
+			ltfsmsg(ALB0283W, flush_ret);
+	}
+
 	if (type == LTFS_FULL_INDEX) {
 		/* Update MAM parameters. */
 		if (partition == ltfs_ip_id(vol))

--- a/src/libltfs/tape.c
+++ b/src/libltfs/tape.c
@@ -448,7 +448,8 @@ int tape_load_tape(struct device_data *dev, void * const kmi_handle, bool force)
 		ltfsmsg(ALP0027E, ret);
 		return ret;
 	}
-	dev->max_block_size = param.max_blksize;
+	dev->max_block_size   = param.max_blksize;
+	dev->needs_wfm_flush  = param.needs_wfm_flush;
 
 	/* Get programmable early warning size */
 	ret = tape_get_pews(dev, &pews);

--- a/src/libltfs/tape.c
+++ b/src/libltfs/tape.c
@@ -450,6 +450,7 @@ int tape_load_tape(struct device_data *dev, void * const kmi_handle, bool force)
 	}
 	dev->max_block_size   = param.max_blksize;
 	dev->needs_wfm_flush  = param.needs_wfm_flush;
+	dev->no_dev_config_ext_subpage = param.no_dev_config_ext_subpage;
 
 	/* Get programmable early warning size */
 	ret = tape_get_pews(dev, &pews);
@@ -2415,13 +2416,15 @@ int tape_set_pews(struct device_data *dev, bool set_value)
 		pews = 0;
 	}
 
+	/* HP LTO-6 lacks the Device Configuration Extension subpage; nothing to set */
+	if (dev->no_dev_config_ext_subpage)
+		return 0;
+
 	/* Issue Mode Sense (MP x10.01) */
 	memset(mp_dev_config_ext, 0, TC_MP_DEV_CONFIG_EXT_SIZE);
 	ret = dev->backend->modesense(dev->backend_data, TC_MP_DEV_CONFIG_EXT, TC_MP_PC_CURRENT, 0x01,
 								  mp_dev_config_ext, TC_MP_DEV_CONFIG_EXT_SIZE);
 	if (ret < 0) {
-		if (ret == -EDEV_INVALID_FIELD_CDB)
-			return 0; /* drive does not support subpage access */
 		ltfsmsg(ALP0073E, ret);
 		return ret;
 	}
@@ -2460,13 +2463,15 @@ int tape_get_pews(struct device_data *dev, uint16_t *pews)
 	CHECK_ARG_NULL(dev->backend_data, -LTFS_NULL_ARG);
 	CHECK_ARG_NULL(pews, -LTFS_NULL_ARG);
 
+	/* HP LTO-6 lacks the Device Configuration Extension subpage */
+	if (dev->no_dev_config_ext_subpage)
+		return -LTFS_UNSUPPORTED;
+
 	/* Issue Mode Sense (MP x10.01) */
 	memset(mp_dev_config_ext, 0, TC_MP_DEV_CONFIG_EXT_SIZE);
 	ret = dev->backend->modesense(dev->backend_data, TC_MP_DEV_CONFIG_EXT, TC_MP_PC_CURRENT, 0x01,
 								  mp_dev_config_ext, TC_MP_DEV_CONFIG_EXT_SIZE);
 	if (ret < 0) {
-		if (ret == -EDEV_INVALID_FIELD_CDB)
-			return -LTFS_UNSUPPORTED; /* drive does not support subpage access */
 		ltfsmsg(ALP0075E, ret);
 		return ret;
 	}
@@ -2503,6 +2508,12 @@ int tape_enable_append_only_mode(struct device_data *dev, bool enable)
 	CHECK_ARG_NULL(dev->backend, -LTFS_NULL_ARG);
 	CHECK_ARG_NULL(dev->backend_data, -LTFS_NULL_ARG);
 
+	/* HP LTO-6 lacks the Device Configuration Extension subpage; append-only unsupported */
+	if (dev->no_dev_config_ext_subpage) {
+		dev->append_only_mode = false;
+		return 0;
+	}
+
 	/* Check cartridge is already loaded not not */
 	for (i = 0; i < 3 && ret < 0; i++) {
 		ret = _tape_test_unit_ready(dev);
@@ -2514,8 +2525,6 @@ int tape_enable_append_only_mode(struct device_data *dev, bool enable)
 	ret = dev->backend->modesense(dev->backend_data, TC_MP_DEV_CONFIG_EXT, TC_MP_PC_CURRENT, 0x01,
 								  mp_dev_config_ext, TC_MP_DEV_CONFIG_EXT_SIZE);
 	if (ret < 0) {
-		if (ret == -EDEV_INVALID_FIELD_CDB)
-			return 0; /* drive does not support subpage access */
 		ltfsmsg(ALP0089E, ret);
 		return ret;
 	}
@@ -2602,13 +2611,18 @@ int tape_get_append_only_mode_setting(struct device_data *dev, bool *enabled)
 	CHECK_ARG_NULL(dev->backend_data, -LTFS_NULL_ARG);
 	CHECK_ARG_NULL(enabled, -LTFS_NULL_ARG);
 
+	/* HP LTO-6 lacks the Device Configuration Extension subpage; append-only unsupported */
+	if (dev->no_dev_config_ext_subpage) {
+		*enabled = false;
+		dev->append_only_mode = false;
+		return 0;
+	}
+
 	/* Issue Mode Sense (MP x10.01) */
 	memset(mp_dev_config_ext, 0, TC_MP_DEV_CONFIG_EXT_SIZE);
 	ret = dev->backend->modesense(dev->backend_data, TC_MP_DEV_CONFIG_EXT, TC_MP_PC_CURRENT, 0x01,
 								  mp_dev_config_ext, TC_MP_DEV_CONFIG_EXT_SIZE);
 	if (ret < 0) {
-		if (ret == -EDEV_INVALID_FIELD_CDB)
-			return 0; /* drive does not support subpage access */
 		ltfsmsg(ALP0091E, ret);
 		return ret;
 	}

--- a/src/libltfs/tape.c
+++ b/src/libltfs/tape.c
@@ -2420,6 +2420,8 @@ int tape_set_pews(struct device_data *dev, bool set_value)
 	ret = dev->backend->modesense(dev->backend_data, TC_MP_DEV_CONFIG_EXT, TC_MP_PC_CURRENT, 0x01,
 								  mp_dev_config_ext, TC_MP_DEV_CONFIG_EXT_SIZE);
 	if (ret < 0) {
+		if (ret == -EDEV_INVALID_FIELD_CDB)
+			return 0; /* drive does not support subpage access */
 		ltfsmsg(ALP0073E, ret);
 		return ret;
 	}
@@ -2463,6 +2465,8 @@ int tape_get_pews(struct device_data *dev, uint16_t *pews)
 	ret = dev->backend->modesense(dev->backend_data, TC_MP_DEV_CONFIG_EXT, TC_MP_PC_CURRENT, 0x01,
 								  mp_dev_config_ext, TC_MP_DEV_CONFIG_EXT_SIZE);
 	if (ret < 0) {
+		if (ret == -EDEV_INVALID_FIELD_CDB)
+			return -LTFS_UNSUPPORTED; /* drive does not support subpage access */
 		ltfsmsg(ALP0075E, ret);
 		return ret;
 	}
@@ -2510,6 +2514,8 @@ int tape_enable_append_only_mode(struct device_data *dev, bool enable)
 	ret = dev->backend->modesense(dev->backend_data, TC_MP_DEV_CONFIG_EXT, TC_MP_PC_CURRENT, 0x01,
 								  mp_dev_config_ext, TC_MP_DEV_CONFIG_EXT_SIZE);
 	if (ret < 0) {
+		if (ret == -EDEV_INVALID_FIELD_CDB)
+			return 0; /* drive does not support subpage access */
 		ltfsmsg(ALP0089E, ret);
 		return ret;
 	}
@@ -2601,6 +2607,8 @@ int tape_get_append_only_mode_setting(struct device_data *dev, bool *enabled)
 	ret = dev->backend->modesense(dev->backend_data, TC_MP_DEV_CONFIG_EXT, TC_MP_PC_CURRENT, 0x01,
 								  mp_dev_config_ext, TC_MP_DEV_CONFIG_EXT_SIZE);
 	if (ret < 0) {
+		if (ret == -EDEV_INVALID_FIELD_CDB)
+			return 0; /* drive does not support subpage access */
 		ltfsmsg(ALP0091E, ret);
 		return ret;
 	}
@@ -2818,18 +2826,22 @@ int tape_takedump_drive(struct device_data *dev, bool nonforced_dump)
 
 char* tape_get_media_encrypted(struct device_data *dev)
 {
+	if (dev->backend->get_media_encrypted) {
+		int ret = dev->backend->get_media_encrypted(dev->backend_data);
+		if (ret >= 0)
+			return ret ? "true" : "false";
+		if (ret != -EDEV_UNSUPPORETD_COMMAND)
+			return "unknown";
+		/* fall through to modesense */
+	}
+
+	/* Generic fallback: modesense page 0x25 (IBM and backends without the new op) */
 	unsigned char buf[TC_MP_READ_WRITE_CTRL_SIZE] = {0};
-	int ret = -EDEV_UNKNOWN;
-	char *encrypted = NULL;
-
-	ret = dev->backend->modesense(dev->backend_data, TC_MP_READ_WRITE_CTRL, TC_MP_PC_CURRENT,
-								  0, buf, sizeof(buf));
+	int ret = dev->backend->modesense(dev->backend_data, TC_MP_READ_WRITE_CTRL, TC_MP_PC_CURRENT,
+									  0, buf, sizeof(buf));
 	if (ret < 0)
-		encrypted = "unknown";
-	else
-		encrypted = (buf[16 + CRYPTO_STATUS] & MEDIUM_SUPPORT_CRYPTO) == 0 ? "false" : "true";
-
-	return encrypted;
+		return "unknown";
+	return (buf[16 + CRYPTO_STATUS] & MEDIUM_SUPPORT_CRYPTO) == 0 ? "false" : "true";
 }
 
 #define CRYPTO_CONTROL        (20)

--- a/src/libltfs/tape.h
+++ b/src/libltfs/tape.h
@@ -110,6 +110,7 @@ struct device_data {
 	bool is_worm;                         /**< Is WORM tape? */
 	bool is_encrypted;                    /**< Is tape encrypted? */
 	struct ltfs_timespec previous_exist;  /**< Previous time to be confirm drive connection presence */
+	bool needs_wfm_flush;                 /**< Drive requires WFM(0) flush after index write (HP/Quantum LTO) */
 
 	struct tape_ops *backend;             /**< Backend functions */
 	void *backend_data;                   /**< Backend private data */

--- a/src/libltfs/tape.h
+++ b/src/libltfs/tape.h
@@ -111,6 +111,7 @@ struct device_data {
 	bool is_encrypted;                    /**< Is tape encrypted? */
 	struct ltfs_timespec previous_exist;  /**< Previous time to be confirm drive connection presence */
 	bool needs_wfm_flush;                 /**< Drive requires WFM(0) flush after index write (HP/Quantum LTO) */
+	bool no_dev_config_ext_subpage;       /**< Drive lacks Device Config Extension subpage MP 0x10.01 (HP LTO-6) */
 
 	struct tape_ops *backend;             /**< Backend functions */
 	void *backend_data;                   /**< Backend private data */

--- a/src/libltfs/tape_ops.h
+++ b/src/libltfs/tape_ops.h
@@ -861,7 +861,9 @@ struct tape_ops {
 	 * @return 1 if the volume contains encrypted logical blocks, 0 if not encrypted,
 	 *         -EDEV_UNSUPPORETD_COMMAND to fall back to modesense page 0x25,
 	 *         or another negative value on error.
-	 * May be NULL; tape.c then falls back to modesense page 0x25.
+	 * Required (tape_device_open() rejects backends with any NULL op). Backends
+	 * without a dedicated implementation should return -EDEV_UNSUPPORETD_COMMAND
+	 * so tape.c falls back to modesense page 0x25.
 	 */
 	int   (*get_media_encrypted)(void *device);
 

--- a/src/libltfs/tape_ops.h
+++ b/src/libltfs/tape_ops.h
@@ -132,6 +132,9 @@ struct tc_drive_param {
 	bool          needs_wfm_flush;       /* Drive requires WFM(0) flush after index write to ensure VCR
 	                                      * is committed to tape before VCI is written to MAM. True for
 	                                      * HP/HPE LTO and Quantum LTO drives. */
+	bool          no_dev_config_ext_subpage; /* Drive does not support the Device Configuration Extension
+	                                      * mode page subpage (MP 0x10 subpage 0x01). True for HP LTO-6;
+	                                      * callers skip PEWS / append-only mode access on such drives. */
 	/* TODO: Following field shall be handled by backend but currently they are not implemented yet */
 	//bool          is_encrypted;          /* Is encrypted tape ? */
 	//bool          is_worm;               /* Is worm tape? */

--- a/src/libltfs/tape_ops.h
+++ b/src/libltfs/tape_ops.h
@@ -129,6 +129,9 @@ struct tc_drive_param {
 	unsigned char density;               /* Current density code */
 	unsigned int  write_protect;         /* Write protect status of the tape (use bit field of volumelock_status) */
 	unsigned int  logical_write_protect; /* Logical Write Protect */
+	bool          needs_wfm_flush;       /* Drive requires WFM(0) flush after index write to ensure VCR
+	                                      * is committed to tape before VCI is written to MAM. True for
+	                                      * HP/HPE LTO and Quantum LTO drives. */
 	/* TODO: Following field shall be handled by backend but currently they are not implemented yet */
 	//bool          is_encrypted;          /* Is encrypted tape ? */
 	//bool          is_worm;               /* Is worm tape? */

--- a/src/libltfs/tape_ops.h
+++ b/src/libltfs/tape_ops.h
@@ -856,6 +856,16 @@ struct tape_ops {
 	int   (*get_keyalias)(void *device, unsigned char **keyalias);
 
 	/**
+	 * Get media encryption status.
+	 * @param device Device handle returned by the backend's open().
+	 * @return 1 if the volume contains encrypted logical blocks, 0 if not encrypted,
+	 *         -EDEV_UNSUPPORETD_COMMAND to fall back to modesense page 0x25,
+	 *         or another negative value on error.
+	 * May be NULL; tape.c then falls back to modesense page 0x25.
+	 */
+	int   (*get_media_encrypted)(void *device);
+
+	/**
 	 * Take a dump from the tape drive.
 	 * @param device Device handle returned by the backend's open().
 	 * @return 0 on success or a negative value on error.

--- a/src/tape_drivers/freebsd/cam/cam_tc.c
+++ b/src/tape_drivers/freebsd/cam/cam_tc.c
@@ -3886,6 +3886,12 @@ bailout:
 	return rc;
 }
 
+int camtape_get_media_encrypted(void *device)
+{
+	/* Defer to tape.c's modesense-based fallback */
+	return -EDEV_UNSUPPORETD_COMMAND;
+}
+
 typedef enum {
 	CT_PP_LBP_R,
 	CT_PP_LBP_W,
@@ -4171,6 +4177,7 @@ struct tape_ops camtape_drive_handler = {
 	.default_device_name    = camtape_default_device_name,
 	.set_key                = camtape_set_key,
 	.get_keyalias           = camtape_get_keyalias,
+	.get_media_encrypted    = camtape_get_media_encrypted,
 	.takedump_drive         = camtape_takedump_drive,
 	.is_mountable           = camtape_is_mountable,
 	.get_worm_status		= camtape_get_worm_status,

--- a/src/tape_drivers/generic/file/filedebug_tc.c
+++ b/src/tape_drivers/generic/file/filedebug_tc.c
@@ -2705,6 +2705,12 @@ int filedebug_get_keyalias(void *device, unsigned char **keyalias)
 	return -EDEV_UNSUPPORTED_FUNCTION;
 }
 
+int filedebug_get_media_encrypted(void *device)
+{
+	/* Defer to tape.c's modesense-based fallback */
+	return -EDEV_UNSUPPORETD_COMMAND;
+}
+
 int filedebug_takedump_drive(void *device, bool nonforced_dump)
 {
 	/* Do nothing */
@@ -2843,6 +2849,7 @@ struct tape_ops filedebug_handler = {
 	.default_device_name    = filedebug_default_device_name,
 	.set_key                = filedebug_set_key,
 	.get_keyalias           = filedebug_get_keyalias,
+	.get_media_encrypted    = filedebug_get_media_encrypted,
 	.takedump_drive         = filedebug_takedump_drive,
 	.is_mountable           = filedebug_is_mountable,
 	.get_worm_status        = filedebug_get_worm_status,

--- a/src/tape_drivers/generic/itdtimg/itdtimg_tc.c
+++ b/src/tape_drivers/generic/itdtimg/itdtimg_tc.c
@@ -1390,6 +1390,12 @@ int itdtimage_get_keyalias(void *device, unsigned char **keyalias)
 	return -EDEV_UNSUPPORTED_FUNCTION;
 }
 
+int itdtimage_get_media_encrypted(void *device)
+{
+	/* Defer to tape.c's modesense-based fallback */
+	return -EDEV_UNSUPPORETD_COMMAND;
+}
+
 int itdtimage_takedump_drive(void *device, bool capture_unforced)
 {
 	/* Do nothing */
@@ -1654,6 +1660,7 @@ struct tape_ops itdtimage_handler = {
 	.default_device_name	= itdtimage_default_device_name,
 	.set_key				= itdtimage_set_key,
 	.get_keyalias			= itdtimage_get_keyalias,
+	.get_media_encrypted	= itdtimage_get_media_encrypted,
 	.takedump_drive			= itdtimage_takedump_drive,
 	.is_mountable			= itdtimage_is_mountable,
 	.get_worm_status		= itdtimage_get_worm_status,

--- a/src/tape_drivers/linux/sg/sg_scsi_tape.h
+++ b/src/tape_drivers/linux/sg/sg_scsi_tape.h
@@ -77,6 +77,16 @@
 #define SK_ILI_SET (0x20)
 #define SK_FM_SET  (0x80)
 
+/* SCSI Security Protocol 0x20 (Tape Data Encryption) page codes (SPS field) */
+#define SPS_DATA_ENCRYPTION_CAPS   (0x0010u) /* Data Encryption Capabilities / Set Data Encryption */
+#define SPS_DATA_ENCRYPTION_STATUS (0x0020u) /* Data Encryption Status */
+#define SPS_NEXT_BLOCK_ENC_STATUS  (0x0021u) /* Next Block Encryption Status */
+
+/* Data Encryption Status page (SPS_DATA_ENCRYPTION_STATUS) field offsets and masks */
+#define DES_ENCR_MODE_BYTE (5)  /* ENCRYPTION MODE: 0 = disabled, non-zero = active */
+#define DES_VCELB_BYTE (13)    /* byte containing the VCELB flag */
+#define DES_VCELB_BIT  (0x01u) /* Volume Contains Encrypted Logical Blocks */
+
 #define PERIPHERAL_MASK   (0x1F)
 #define SEQUENTIAL_DEVICE (0x01)
 

--- a/src/tape_drivers/linux/sg/sg_tape.c
+++ b/src/tape_drivers/linux/sg/sg_tape.c
@@ -4283,6 +4283,11 @@ int sg_get_parameters(void *device, struct tc_drive_param *params)
 	else
 		params->max_blksize = MIN(_cdb_read_block_limits(device), SG_MAX_BLOCK_SIZE);
 
+	params->needs_wfm_flush = IS_LTO(priv->drive_type) &&
+		(priv->vendor == VENDOR_HP ||
+		 priv->vendor == VENDOR_QUANTUM ||
+		 priv->vendor == VENDOR_QUANTUM_B);
+
 	ret = 0;
 
 out:

--- a/src/tape_drivers/linux/sg/sg_tape.c
+++ b/src/tape_drivers/linux/sg/sg_tape.c
@@ -4288,6 +4288,12 @@ int sg_get_parameters(void *device, struct tc_drive_param *params)
 		 priv->vendor == VENDOR_QUANTUM ||
 		 priv->vendor == VENDOR_QUANTUM_B);
 
+	/* HP LTO-6 does not support the Device Configuration Extension mode page
+	 * subpage (MP 0x10 subpage 0x01); callers must skip PEWS / append-only access. */
+	params->no_dev_config_ext_subpage = IS_LTO(priv->drive_type) &&
+		priv->vendor == VENDOR_HP &&
+		DRIVE_GEN(priv->drive_type) == 0x06;
+
 	ret = 0;
 
 out:

--- a/src/tape_drivers/linux/sg/sg_tape.c
+++ b/src/tape_drivers/linux/sg/sg_tape.c
@@ -4699,17 +4699,43 @@ static bool is_ame(void *device)
 	}
 }
 
+static bool is_tde_capable(void *device)
+{
+	   unsigned char *buffer = NULL;
+	   size_t size = 0;
+	   const int ret = _cdb_spin(device, SPS_DATA_ENCRYPTION_CAPS, &buffer, &size);
+	   free(buffer);
+
+	   if (ret != 0) {
+			char message[100] = {0};
+			sprintf(message, "failed to query DEC page (%d)", ret);
+			ltfsmsg(ATG0099D, __FUNCTION__, message);
+			return false;
+	   }
+
+	   return size > 0;
+}
+
 static int is_encryption_capable(void *device)
 {
 	struct sg_data *priv = (struct sg_data*)device;
 
-	if (IS_LTO(priv->drive_type)) {
+	if (IS_ENTERPRISE(priv->drive_type)) {
+		/* Jaguar: must already be configured for Application Managed Encryption */
+		if (! is_ame(device)) {
+			ltfsmsg(ATG0044E, priv->drive_type);
+			return -EDEV_INTERNAL_ERROR;
+		}
+	} else if (IS_LTO(priv->drive_type)) {
+		/* LTO (HP, Quantum, IBM LTO via sg): verify drive advertises TDE algorithms */
+		if (! is_tde_capable(device)) {
+			ltfsmsg(ATG0044E, priv->drive_type);
+			return -EDEV_INTERNAL_ERROR;
+		}
+	} else {
 		ltfsmsg(ATG0044E, priv->drive_type);
 		return -EDEV_INTERNAL_ERROR;
 	}
-
-	if (! is_ame(device))
-		return -EDEV_INTERNAL_ERROR;
 
 	return DEVICE_GOOD;
 }
@@ -4732,7 +4758,7 @@ int sg_set_key(void *device, const unsigned char *keyalias, const unsigned char 
 		return ret;
 	}
 
-	const uint16_t sps = 0x10;
+	const uint16_t sps = SPS_DATA_ENCRYPTION_CAPS;
 	const size_t size = keyalias ? 20 + DK_LENGTH + 4 + DKI_LENGTH : 20;
 	uint8_t *buffer = calloc(size, sizeof(uint8_t));
 	if (! buffer) {
@@ -4742,9 +4768,14 @@ int sg_set_key(void *device, const unsigned char *keyalias, const unsigned char 
 	}
 
 	unsigned char buf[TC_MP_READ_WRITE_CTRL_SIZE] = {0};
-	ret = sg_modesense(device, TC_MP_READ_WRITE_CTRL, TC_MP_PC_CURRENT, 0, buf, sizeof(buf));
-	if (ret != DEVICE_GOOD)
-		goto out;
+
+	/* HP LTO drives do not support Mode Page 0x25. */
+	if (!(priv->vendor == VENDOR_HP && IS_LTO(priv->drive_type) &&
+		((DRIVE_GEN(priv->drive_type) == 0x05 || DRIVE_GEN(priv->drive_type) == 0x06 )))) {
+		ret = sg_modesense(device, TC_MP_READ_WRITE_CTRL, TC_MP_PC_CURRENT, 0, buf, sizeof(buf));
+		if (ret != DEVICE_GOOD)
+		    goto out;
+	}
 
 	ltfs_u16tobe(buffer + 0, sps);
 	ltfs_u16tobe(buffer + 2, size - 4);
@@ -4788,10 +4819,14 @@ int sg_set_key(void *device, const unsigned char *keyalias, const unsigned char 
 
 	priv->dev.is_data_key_set = keyalias != NULL;
 
-	memset(buf, 0, sizeof(buf));
-	ret = sg_modesense(device, TC_MP_READ_WRITE_CTRL, TC_MP_PC_CURRENT, 0, buf, sizeof(buf));
-	if (ret != DEVICE_GOOD)
-		goto out;
+	/* HP LTO drives do not support Mode Page 0x25. */
+	if (!(priv->vendor == VENDOR_HP && IS_LTO(priv->drive_type) &&
+	    ((DRIVE_GEN(priv->drive_type) == 0x05 || DRIVE_GEN(priv->drive_type) == 0x06 )))) {
+	    memset(buf, 0, sizeof(buf));
+	    ret = sg_modesense(device, TC_MP_READ_WRITE_CTRL, TC_MP_PC_CURRENT, 0, buf, sizeof(buf));
+	    if (ret != DEVICE_GOOD)
+			goto out;
+	}
 
 free:
 	free(buffer);
@@ -4850,7 +4885,7 @@ int sg_get_keyalias(void *device, unsigned char **keyalias)
 		return ret;
 	}
 
-	const uint16_t sps = 0x21;
+	const uint16_t sps = SPS_NEXT_BLOCK_ENC_STATUS;
 	uint8_t *buffer = NULL;
 	size_t size = 0;
 	int i = 0;
@@ -4906,6 +4941,28 @@ free:
 	free(buffer);
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_GETKEYALIAS));
 	return ret;
+}
+
+static int sg_get_media_encrypted(void *device)
+{
+	struct sg_data *priv = (struct sg_data*)device;
+
+	if (!(priv->vendor == VENDOR_HP && IS_LTO(priv->drive_type)))
+		return -EDEV_UNSUPPORETD_COMMAND;
+
+	/* HP LTO does not support Mode Page 0x25; use SPIN Data Encryption Status page */
+	unsigned char *buffer = NULL;
+	size_t size = DES_ENCR_MODE_BYTE + 1;
+	const size_t alloc = size + 4;
+	int ret = _cdb_spin(device, SPS_DATA_ENCRYPTION_STATUS, &buffer, &size);
+	show_hex_dump("DES SPIN:", buffer, alloc);
+	if (ret != DEVICE_GOOD || size < DES_ENCR_MODE_BYTE + 1) {
+		free(buffer);
+		return -EDEV_UNKNOWN;
+	}
+	int encrypted = buffer[DES_ENCR_MODE_BYTE] != 0;
+	free(buffer);
+	return encrypted;
 }
 
 int sg_takedump_drive(void *device, bool capture_unforced)
@@ -5291,6 +5348,7 @@ struct tape_ops sg_handler = {
 	.default_device_name    = sg_default_device_name,
 	.set_key                = sg_set_key,
 	.get_keyalias           = sg_get_keyalias,
+	.get_media_encrypted    = sg_get_media_encrypted,
 	.takedump_drive         = sg_takedump_drive,
 	.is_mountable           = sg_is_mountable,
 	.get_worm_status        = sg_get_worm_status,

--- a/src/tape_drivers/netbsd/scsipi-ibmtape/scsipi_ibmtape.c
+++ b/src/tape_drivers/netbsd/scsipi-ibmtape/scsipi_ibmtape.c
@@ -4369,6 +4369,12 @@ free:
 	return ret;
 }
 
+int scsipi_ibmtape_get_media_encrypted(void *device)
+{
+	/* Defer to tape.c's modesense-based fallback */
+	return -EDEV_UNSUPPORETD_COMMAND;
+}
+
 int scsipi_ibmtape_takedump_drive(void *device, bool capture_unforced)
 {
 	struct scsipi_ibmtape_data *priv = (struct scsipi_ibmtape_data*)device;
@@ -4610,6 +4616,7 @@ struct tape_ops scsipi_ibmtape_handler = {
 	.default_device_name    = scsipi_ibmtape_default_device_name,
 	.set_key                = scsipi_ibmtape_set_key,
 	.get_keyalias           = scsipi_ibmtape_get_keyalias,
+	.get_media_encrypted    = scsipi_ibmtape_get_media_encrypted,
 	.takedump_drive         = scsipi_ibmtape_takedump_drive,
 	.is_mountable           = scsipi_ibmtape_is_mountable,
 	.get_worm_status        = scsipi_ibmtape_get_worm_status,

--- a/src/tape_drivers/osx/iokit/iokit_tape.c
+++ b/src/tape_drivers/osx/iokit/iokit_tape.c
@@ -4094,6 +4094,12 @@ free:
 	return ret;
 }
 
+int iokit_get_media_encrypted(void *device)
+{
+	/* Defer to tape.c's modesense-based fallback */
+	return -EDEV_UNSUPPORETD_COMMAND;
+}
+
 int iokit_takedump_drive(void *device, bool capture_unforced)
 {
 	struct iokit_data *priv = (struct iokit_data*)device;
@@ -4340,6 +4346,7 @@ struct tape_ops iokit_handler = {
 	.default_device_name    = iokit_default_device_name,
 	.set_key                = iokit_set_key,
 	.get_keyalias           = iokit_get_keyalias,
+	.get_media_encrypted    = iokit_get_media_encrypted,
 	.takedump_drive         = iokit_takedump_drive,
 	.is_mountable           = iokit_is_mountable,
 	.get_worm_status        = iokit_get_worm_status,


### PR DESCRIPTION
## What

Allow to read/write encrypted tapes for HP LTO drives. I suspect that this might enable most of generations to work, but I lack a hardware to test with, so I'm targeting LTO-6 for now.

This fixes the following previously reported issues (if we don't mind referencing issues from the LTFS project):
* #LinearTapeFileSystem/ltfs/issues/201
* #LinearTapeFileSystem/ltfs/issues/490
* #LinearTapeFileSystem/ltfs/issues/498

## How

Initially I've started working on LTFS sources with Claude Code, then switched to Aurora, then rebased a few times to adapt to the current changes, testing my changes on the real hardware over and over again.

I've inspected stenc and understood how it configures encryption for HP drives, then implemented it in Aurora, trying to follow the project structure. Also I've decided to tolerate some errors for HP drives to clean up the output - it should be safe as it properly gated and doesn't affect operation.

After that I've investigated unwanted full medium consistency check and traced it to VCR/VCI mismatch, confirmed that it doesn't depend on tape generation, vendor and session write amount, and then found a solution in HPE LTFS sources - a proper WFM flush.

## Testing

Tested with a real drive: Ultrium 6250 FC - LTO-5, LTO-6, both plain and encrypted. Let me know if additional details or testing specific scenarios are needed.

### Test environment

- Tested on: Ubuntu 24.04 - compiles; Arch Linux - compiles and works (altfs, mkaltfs).
- Added automated tests: None

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## AI Usage

- [ ] No AI tools were used in this contribution
- [x] AI tools were used (please describe below)

**AI tool(s) used:** Claude Code (mostly Sonnet, and Opus for verification)
**Scope of AI assistance:** understanding project's structure and operation, writing the code, review.