### PR TITLE
fix(altfsindextool): widen index-key scan via memmem 

### DIFF
--- a/src/cmd/altfsindextool/altfsindextool.c
+++ b/src/cmd/altfsindextool/altfsindextool.c
@@ -97,7 +97,7 @@ struct indextool_opts {
 #define PART_BOTH  (-1)
 #define START_POS  (5)
 #define OUTPUT_DIR "."
-#define KEY_MAX_OFFSET  (0x30)
+#define INDEX_KEY  "<ltfsindex"
 
 static const char *short_options = "i:e:d:p:s:o:b:qthV";
 static struct option long_options[] = {
@@ -161,7 +161,7 @@ static int ltfs_capture_index_raw(tape_partition_t   part,
 	int ret = 0, fd = -1;
 	ssize_t nread, nwrite, index_len = 0;
 	struct tc_position pos;
-	char *buf = NULL, *key = NULL, check_buf[KEY_MAX_OFFSET + 1];
+	char *buf = NULL, *key = NULL;
 
 	pos.partition = part;
 	pos.block = start_pos;
@@ -196,10 +196,8 @@ static int ltfs_capture_index_raw(tape_partition_t   part,
 		}
 		pos.block++;
 
-		memset(check_buf, 0x00, KEY_MAX_OFFSET + 1);
-		strncpy(check_buf, buf, KEY_MAX_OFFSET);
-		key = strstr(check_buf, "<ltfsindex");
-		if (key && (key - buf < 0x30)) {
+		key = memmem(buf, nread, INDEX_KEY, strlen(INDEX_KEY));
+		if (key) {
 			ltfsmsg(AIX0030I,
 					(unsigned int)pos.partition, (unsigned long long)(pos.block - 1));
 
@@ -258,16 +256,10 @@ static int ltfs_capture_index_raw(tape_partition_t   part,
 			_close_output_file(fd);
 		} else {
 			/* seek to next FM */
-			if (key)
-				ltfsmsg(AIX0031I,
-						(unsigned int)pos.partition,
-						(unsigned long long)(pos.block - 1),
-						(int)(key - buf));
-			else
-				ltfsmsg(AIX0031I,
-						(unsigned int)pos.partition,
-						(unsigned long long)(pos.block - 1),
-						(int)0);
+			ltfsmsg(AIX0031I,
+					(unsigned int)pos.partition,
+					(unsigned long long)(pos.block - 1),
+					(int)0);
 
 			/* Do nothig at (nread == 0) because tape hits a FM */
 			if (nread > 0) {

--- a/tests/common/index.py
+++ b/tests/common/index.py
@@ -1,39 +1,60 @@
-"""Independent inspection of LTFS index XML records on the file backend.
+"""Independent inspection of LTFS index XML records.
 
-These helpers parse the XML with Python's stdlib (xml.etree), which
-shares no code with altfs's libxml2-based parser. A structural bug
-that altfs's writer + reader both round-trip cleanly can still be
-caught here.
+These helpers capture the on-tape index with `altfsindextool`
+and parse the resulting XML with Python's stdlib (xml.etree),
+which shares no code with altfs's libxml2-based parser. A
+structural bug that altfs's writer + reader both round-trip
+cleanly can still be caught here.
+
+The capture step (`altfsindextool ... --output-dir=...`) is the
+public extraction path, so it works regardless of which tape
+backend wrote the index — tests do not need to know how the
+file backend names its on-disk records.
 """
 
-import os
-import re
+import subprocess
+import tempfile
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
-_IP_RECORD_RE = re.compile(r"^0_(\d+)_R$")
+
+_RUN_TIMEOUT = 30
 
 
-def find_latest_index_record(tape_dir):
-    """Path to the highest-numbered IP record file whose content begins
-    with an <ltfsindex> element (skips the VOL1 label and <ltfslabel>)."""
-    candidates = []
-    for name in os.listdir(tape_dir):
-        m = _IP_RECORD_RE.match(name)
-        if not m:
-            continue
-        path = Path(tape_dir) / name
-        if b"<ltfsindex" in path.read_bytes()[:64]:
-            candidates.append((int(m.group(1)), path))
-    if not candidates:
-        raise RuntimeError(f"no ltfsindex record found in {tape_dir}")
-    candidates.sort()
-    return candidates[-1][1]
+def _capture_indexes(tape_dir, partition, dest):
+    subprocess.run(
+        ["altfsindextool",
+         "-e", "file",
+         "-d", str(tape_dir),
+         f"--partition={partition}",
+         f"--output-dir={dest}",
+         "--quiet"],
+        check=True,
+        capture_output=True,
+        timeout=_RUN_TIMEOUT,
+    )
 
 
-def parse_latest_index(tape_dir):
-    """Parse the latest IP index XML and return the root element."""
-    return ET.parse(find_latest_index_record(tape_dir)).getroot()
+def _latest_captured(dest, partition):
+    files = list(Path(dest).glob(f"ltfs-index-{partition}-*.xml"))
+    if not files:
+        raise RuntimeError(
+            f"altfsindextool captured no index for partition {partition} "
+            f"under {dest}"
+        )
+    return max(files, key=lambda p: int(p.stem.rsplit("-", 1)[-1]))
+
+
+def parse_latest_index(tape_dir, partition=0):
+    """Capture every index on `partition` and parse the highest-block
+    one. Returns the parsed XML root element.
+
+    Defaults to partition 0 (index partition): the IP carries the
+    most recent index after `sync_type=unmount` finishes, so a
+    single capture there yields the latest committed state."""
+    with tempfile.TemporaryDirectory(prefix="altfs-idxcap-") as dest:
+        _capture_indexes(tape_dir, partition, dest)
+        return ET.parse(_latest_captured(dest, partition)).getroot()
 
 
 def find_entries_by_name(root, names):

--- a/tests/fsapi/test_percent_encoding.py
+++ b/tests/fsapi/test_percent_encoding.py
@@ -16,10 +16,8 @@ umount → inspect the IP record with the stdlib XML parser → re-mount
 → verify names come back identical and content is intact.
 """
 
-import xml.etree.ElementTree as ET
-
 from common.altfs import format_tape, mount_tape, umount_tape
-from common.index import find_latest_index_record
+from common.index import parse_latest_index
 
 
 FILE_NAME = "log:2026-06-16.txt"        # `:` triggers percent encoding
@@ -57,9 +55,7 @@ def test_percent_encoded_names_round_trip(tmp_path_factory):
 
     # Inspect the raw XML: the writer should have emitted the colon
     # as %3A and tagged the element percentencoded="true".
-    index_path = find_latest_index_record(tape_dir)
-    tree = ET.parse(index_path)
-    root = tree.getroot()
+    root = parse_latest_index(tape_dir)
 
     by_encoded_name = {}
     for tag, name_el in _walk_named_entries(root):

--- a/tests/scenarios/test_altfsindextool.py
+++ b/tests/scenarios/test_altfsindextool.py
@@ -1,0 +1,123 @@
+"""Integration coverage for altfsindextool capture mode.
+
+altfsindextool walks the tape and writes one
+`ltfs-index-<partition>-<block>.xml` file per index record it
+finds. These tests run capture against tapes built with the
+file backend and verify the output via stdlib XML parsing —
+they do not assume anything about the file backend's on-disk
+record naming, so the same assertions exercise the tool's
+public output contract end-to-end.
+
+A regression of the strstr/strncpy scan window bug (Issue #38)
+would manifest here as an empty output directory despite
+exit-zero, which is exactly what every assertion below catches.
+"""
+
+import subprocess
+import xml.etree.ElementTree as ET
+
+from common.altfs import format_tape, mount_tape, umount_tape
+
+
+_RUN_TIMEOUT = 30
+
+
+def _indextool(tape_dir, output_dir, *extra_args):
+    return subprocess.run(
+        ["altfsindextool", "-e", "file", "-d", str(tape_dir),
+         f"--output-dir={output_dir}", *extra_args],
+        capture_output=True,
+        text=True,
+        timeout=_RUN_TIMEOUT,
+    )
+
+
+def test_capture_clean_tape_writes_initial_index_on_both_partitions(tmp_path_factory):
+    """A freshly formatted tape carries the initial index at block 5
+    on both partitions. Default capture (no --partition) must
+    produce exactly those two files and nothing else."""
+    base = tmp_path_factory.mktemp("indextool-clean")
+    tape_dir = base / "tape"
+    out = base / "out"
+    tape_dir.mkdir()
+    out.mkdir()
+    format_tape(tape_dir, serial="IDXCL0", label="indextool-clean")
+
+    r = _indextool(tape_dir, out)
+    assert r.returncode == 0, r.stderr
+
+    names = sorted(p.name for p in out.iterdir())
+    assert names == ["ltfs-index-0-5.xml", "ltfs-index-1-5.xml"], names
+
+    for p in out.iterdir():
+        root = ET.parse(p).getroot()
+        assert root.tag == "ltfsindex"
+        # Every index carries the volume UUID; presence confirms
+        # we captured a full index record, not a truncated fragment.
+        assert root.find("volumeuuid") is not None
+
+
+def test_capture_partition_override_restricts_output(tmp_path_factory):
+    """`--partition=0 --start-pos=5` should produce only the IP
+    index, not the DP copy."""
+    base = tmp_path_factory.mktemp("indextool-ip")
+    tape_dir = base / "tape"
+    out = base / "out"
+    tape_dir.mkdir()
+    out.mkdir()
+    format_tape(tape_dir, serial="IDXIP0", label="indextool-ip")
+
+    r = _indextool(tape_dir, out, "--partition=0", "--start-pos=5")
+    assert r.returncode == 0, r.stderr
+
+    names = sorted(p.name for p in out.iterdir())
+    assert names == ["ltfs-index-0-5.xml"], names
+
+
+def test_capture_after_writes_picks_up_new_dp_index(tmp_path_factory):
+    """Mount → write → unmount (sync_type=unmount) appends new
+    DP indexes past block 5. Capture on partition 1 must therefore
+    produce more than one file, and the latest one must reflect
+    the new file we wrote."""
+    base = tmp_path_factory.mktemp("indextool-write")
+    tape_dir = base / "tape"
+    mnt = base / "mnt"
+    out = base / "out"
+    tape_dir.mkdir()
+    mnt.mkdir()
+    out.mkdir()
+
+    format_tape(tape_dir, serial="IDXWR0", label="indextool-write")
+    mount_tape(tape_dir, mnt)
+    try:
+        (mnt / "hello.txt").write_text("indextool test")
+    finally:
+        umount_tape(mnt)
+
+    r = _indextool(tape_dir, out, "--partition=1")
+    assert r.returncode == 0, r.stderr
+
+    dp_files = list(out.iterdir())
+    assert len(dp_files) >= 2, [p.name for p in dp_files]
+
+    latest = max(dp_files, key=lambda p: int(p.stem.rsplit("-", 1)[-1]))
+    root = ET.parse(latest).getroot()
+    names = {e.text for e in root.iter("name")}
+    assert "hello.txt" in names, names
+
+
+def test_capture_quiet_still_writes_files(tmp_path_factory):
+    """--quiet suppresses LTFSAIX info messages but the captured
+    files must still appear."""
+    base = tmp_path_factory.mktemp("indextool-quiet")
+    tape_dir = base / "tape"
+    out = base / "out"
+    tape_dir.mkdir()
+    out.mkdir()
+    format_tape(tape_dir, serial="IDXQT0", label="indextool-quiet")
+
+    r = _indextool(tape_dir, out, "--quiet")
+    assert r.returncode == 0, r.stderr
+    # Quiet should silence the AIX0030I "Reading an index" lines.
+    assert "LTFSAIX0030I" not in (r.stdout + r.stderr)
+    assert list(out.iterdir())


### PR DESCRIPTION
## What

Fix Issue #38: `altfsindextool` capture mode failed to recognize any block as an index, so it walked the tape and exited 0 with an empty `--output-dir`. Also add direct integration coverage for the capture contract, and route the test helper that inspects on-tape indexes through `altfsindextool` instead of poking at the file backend's internal record naming.

Fixes #38

## How

- `src/cmd/altfsindextool/altfsindextool.c::ltfs_capture_index_raw`: replace the `strncpy` + `strstr` scan (a 48-byte truncated copy that dropped the last byte of `<ltfsindex`) with `memmem(buf, nread, "<ltfsindex", ...)`. Drop `KEY_MAX_OFFSET` and `check_buf`, and fold away the now-unreachable "key found but offset rejected" branch so AIX0031I is logged once.
- Add `tests/scenarios/test_altfsindextool.py` (4 cases): clean tape produces an index on both partitions, `--partition` restricts output, post-write captures pick up the new DP index, and `--quiet` still emits files. The first case fails on the unpatched code at the empty-output-dir assertion.
- Refactor `tests/common/index.py` to extract indexes via `altfsindextool --output-dir=<tmp> --quiet` instead of grepping for `0_<n>_R` files. The helper is now backend-agnostic, and every existing caller of `parse_latest_index` (round-trip, xattr, unicode names, percent-encoding) exercises `altfsindextool` on the same code path.
- `find_latest_index_record` had a single in-tree caller; collapse `tests/fsapi/test_percent_encoding.py` onto `parse_latest_index` and remove the helper.

## Why (optional)

The fix takes Option 2 from the issue write-up. Treating the first N bytes of a block as a NUL-terminated C string coupled the search to (a) a magic offset (`0x30`) that had to track the XML declaration length, and (b) implicit "no embedded NUL" assumptions about block content. Searching with an explicit length via `memmem` removes both.

Routing the test helper through `altfsindextool` puts the tool itself on the hot path for every test that inspects an on-tape index, so a regression in capture mode now surfaces beyond the dedicated test file.

## Testing

### Test steps

- Ran the Issue #38 reproduction (`mkaltfs -e file` then `altfsindextool -e file --output-dir=/tmp/out`) and confirmed `ltfs-index-0-5.xml` and `ltfs-index-1-5.xml` appear in `/tmp/out`.
- `tests/scenarios/run.sh`: 36 passed (includes the 4 new altfsindextool cases).
- `tests/fsapi/run.sh`: 72 passed (the 4 callers of `parse_latest_index` now go through the new capture-based helper).

### Test environment

- Tested on: Ubuntu 24.04 (devcontainer), `file` backend
- Added automated tests: `tests/scenarios/test_altfsindextool.py` (4 cases)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## AI Usage

- [ ] No AI tools were used in this contribution
- [x] AI tools were used (please describe below)

**AI tool(s) used:** Claude Code (Opus 4.7)
**Scope of AI assistance:** Confirming the root cause, implementing the `memmem` replacement, writing the new test file, refactoring `tests/common/index.py`, and drafting this PR description. All output was reviewed and edited by the author.
